### PR TITLE
Avoid error on windows

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -30,7 +30,7 @@ endfunction
 " Utility {{{
 
 function! s:current_file()
-  return expand('%')
+  return expand("%:p")
 endfunction
 
 function! s:is_in_a_git_repo()


### PR DESCRIPTION
In order to avoid an error "Invalid filename", this little fix get gitgutter working on windows with msysgit
