### PR TITLE
Escape ' characters in filepaths.

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -70,7 +70,7 @@ function! s:exists_current_file()
 endfunction
 
 function! s:directory_of_current_file()
-  return expand("%:p:h")
+  return shellescape(expand("%:p:h"))
 endfunction
 
 function! s:command_in_directory_of_current_file(cmd)


### PR DESCRIPTION
is_in_a_repo() throws an error, if the path to the current file contains a ' character, because directory_of_current_file() returns an unescaped path.
