### PR TITLE
Add FAQ note for git diff color settings.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -56,6 +56,14 @@ If you want to define your own highlights, you can turn off vim-gitgutter's with
 
 ### FAQ
 
+> I'm not seeing anything even though I just modified the file.
+
+Make sure that your color settings for ```git diff``` are set to auto:
+
+```
+git config --global color.diff auto
+```
+
 > The colours in the sign column are weird.
 
 The syntax highlighting for your sign column is probably set strangely.  Either modify your colorscheme or add this to your `~/.vimrc`:


### PR DESCRIPTION
I found that my git config had color.diff = always, and this caused the
grep command (grep -e "^@@ "') to return no matches when diffing
the file in s:run_diff().
