### PR TITLE
Disable diff colors for grep

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -103,7 +103,7 @@ endfunction
 " Diff processing {{{
 
 function! s:run_diff()
-  let cmd = 'git diff --no-ext-diff -U0 ' . shellescape(s:current_file()) .
+  let cmd = 'git diff --no-ext-diff --no-color -U0 ' . shellescape(s:current_file()) .
         \ ' | grep -e "^@@ "'
   let diff = system(s:command_in_directory_of_current_file(cmd))
   return diff


### PR DESCRIPTION
Color codes can mess with the diff grep and disable detecting line changes. Pass the --no-color flag to override git config and remove color codes from the output.
