### PR TITLE
Allow user to define the signs.

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -20,7 +20,7 @@ endif
 function! s:init()
   if !exists('g:gitgutter_initialised')
     let s:highlight_lines = 0
-    if g:gitgutter_highlights
+    if g:gitgutter_signs
       call s:define_signs()
     endif
 


### PR DESCRIPTION
Beware, I'm a vimscript novice.  I just copied the pattern for user-defined highlights and this seems to be working for me.

I removed the call to define_signs() in update_line_highlights() -- if it's necessary to redefine them there, I guess we have to figure out a way to do that.
