### PR TITLE
Highlighting customization tweaks

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -22,9 +22,7 @@ function! s:init()
     let s:highlight_lines = g:gitgutter_highlight_lines
     call s:define_signs()
 
-    if g:gitgutter_highlights
-      call s:define_highlights()
-    endif
+    call s:define_highlights()
 
     " Vim doesn't namespace sign ids so every plugin shares the same
     " namespace.  Sign ids are simply integers so to avoid clashes with other


### PR DESCRIPTION
### highlight groups for signs
- renamed highlight groups with `GitGutter` prefix, and following the
  naming style of the builtin groups `DiffAdd`, `DiffChange`, etc.
- using `highlight default link` to set default colours for
  signs.  e.g. the plugin defines `GitGutterAddDefault` as green, and
  (if `g:gitgutter_highlights`) default links `GitGutterAdd` to it
  (which the user can customize).  The default highlight group pattern
  also means users can always reference the plugin's default value
  if they're messing around with their colours on the fly.
### highlight groups for lines
- added `g:gitgutter_highlight_lines` option
  
  This lets a user decide whether to start with lines highlighted.
  This could be done by calling `GitGutterLineHighlightsEnable`, but
  making it an option makes it more consistent with the other options.
  It still defaults to off.
- added gitgutter-specific highlight groups for line highlighting
  (`GitGutterAddLine`, etc) so that this highlighting can be customized
  independent of `DiffAdd` et al (which these default link to).
- line highlighting toggling now only changes the `linehl` attribute
  
  The `linehl` attribute is toggled in `s:update_line_highlights`,
  which separates concerns more clearly.  I'm thinking ahead to
  the possibility of the sign text being configurable, and thinking
  it will be DRYer to keep these things separate.  Maybe it's just
  aesthetic though.
### bonus

resolved "eugh" ;)
