### PR TITLE
Try to guess what colour to set the SignColumn

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -14,7 +14,7 @@ if !exists('g:gitgutter_highlights')
 endif
 
 if !exists('g:gitgutter_fix_bg')
-  let g:gitgutter_fix_bg = 1
+  let g:gitgutter_fix_bg = 0
 endif
 
 function! s:init()


### PR DESCRIPTION
A response to #32 (if there's a way to link a pull request to an existing issue I don't know it!)

I was playing around seeing how "intelligently" I could guess colour settings for the SignColumn.  This seems to work well, but it might be overkill? Haha.

Adds a new option, `g:gitgutter_fix_bg`

If set to `1`, it will try to steal the colour scheme of the user's
numberline (`LineNr`) if they currently have it turned on, otherwise will try to set
it based on `&background`.

If set to `'light'` or `'dark'` it will try
to set it as if `&background` were set to that (even if it's not).
If it steals the highlighting from `LineNr`, it tries to figure
out if it seems light or dark.  It uses this to choose a brighter
or darker palette for the sign symbols.

If set to `0`, nothing happens.  Default is currently `0`, so as not to annoy anyone who has their colour scheme already set up right.
