### PR TITLE
Windows gvim infinite shell loop fix

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -457,7 +457,7 @@ endfunction
 augroup gitgutter
   autocmd!
   autocmd BufReadPost,BufWritePost,FileReadPost,FileWritePost * call GitGutter()
-  if !(has("gui_win32"))
+  if !has("gui_win32")
     autocmd FocusGained * call GitGutter()
   endif
 augroup END


### PR DESCRIPTION
In gvim on windows, a shell would keep spawning, causing vim to become unusable. This loop was caused by the FocusGained autocmd. I just put the autocmd in a conditional that only looks for gvim on windows (terminal vim is okay).
