### PR TITLE
Run GitGutter when re-entering split window.

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -456,7 +456,7 @@ endfunction
 
 augroup gitgutter
   autocmd!
-  autocmd BufReadPost,BufWritePost,FileReadPost,FileWritePost,FocusGained * call GitGutter()
+  autocmd BufReadPost,BufWritePost,FileReadPost,FileWritePost,FocusGained,WinEnter * call GitGutter()
 augroup END
 
 " }}}


### PR DESCRIPTION
Nearly identical to b6c5364, update the signs on the buffer when
re-entering the split window. This is probably only used in addition to
other Git related vim plugins, like vim-fugitive by @tpope, when used
inside the same terminal session. :Gcommit opens a new split window to
enter the message, and afterwards switches back to the window previously
in focus. This should automatically update the signs then.
