### PR TITLE
Fix GitGutter when using Vim Fugitive

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -497,7 +497,7 @@ endfunction
 
 augroup gitgutter
   autocmd!
-  autocmd BufReadPost,BufWritePost,FileReadPost,FileWritePost * call GitGutter(s:current_file())
+  autocmd BufReadPost,BufWritePost,FileReadPost,FileWritePost,BufEnter * call GitGutter(s:current_file())
   if !has('gui_win32')
     autocmd FocusGained * call GitGutterAll()
   endif


### PR DESCRIPTION
Added the GitGutter call to BufEnter as well since this is often the
only way to trigger updates to GitGutter display after I have committed
from another split and returned to the current one.
