### PR TITLE
enable user to set a upstream per repo as 'GUTTER_HEAD'

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -197,8 +197,11 @@ endfunction
 " Diff processing {{{
 
 function! s:run_diff()
-  let cmd = 'git diff --no-ext-diff --no-color -U0 ' . g:gitgutter_diff_args . ' ' .
-        \ shellescape(s:file()) .  ' | grep -e "^@@ "'
+  let cmd = 'git diff GUTTER_HEAD --no-ext-diff --no-color -U0 ' . g:gitgutter_diff_args . ' ' .
+        \ shellescape(s:file()) .
+        \ ' || git diff --no-ext-diff --no-color -U0 ' . g:gitgutter_diff_args . ' ' .
+        \ shellescape(s:file()) .
+        \ ' | grep -e "^@@ "'
   let diff = system(s:command_in_directory_of_file(cmd))
   return diff
 endfunction


### PR DESCRIPTION
When GUTTER_HEAD is set in current repository, `git diff GUTTER_HEAD` will be used instead of `git diff`. 

It will be useful when (re)developing based on an upstream branch.

As an alternative, setting a branch name to `g:gitgutter_diff_args` will usually work, except when we need to develop with two or more repositories.
