### PR TITLE
Can't disable gitgutter when gitgutter_sign_column_always=1

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -326,6 +326,7 @@ endfunction
 " Sign processing {{{
 
 function! s:clear_signs(file_name)
+  exe ":sign unplace" s:dummy_sign_id "file=" . a:file_name
   if exists('s:sign_ids') && has_key(s:sign_ids, a:file_name)
     for id in s:sign_ids[a:file_name]
       exe ":sign unplace" id "file=" . a:file_name
@@ -411,10 +412,10 @@ function! GitGutter(file)
     let diff = s:run_diff()
     let s:hunks = s:parse_diff(diff)
     let modified_lines = s:process_hunks(s:hunks)
+    call s:clear_signs(a:file)
     if g:gitgutter_sign_column_always
       call s:add_dummy_sign()
     endif
-    call s:clear_signs(a:file)
     call s:find_other_signs(a:file)
     call s:show_signs(a:file, modified_lines)
   endif


### PR DESCRIPTION
This commit fixes an issue with gitgutter_sign_column_always=1 where disabling
the gitgutter wouldn't remove the dummy sign used to keep it open when no other
signs are present.

This problem causes the gitgutter to always be visible, even when disabling it.
