### PR TITLE
Prevent clearing highlight definitions when colorscheme changed

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -528,6 +528,7 @@ augroup gitgutter
     endif
     autocmd TabEnter * call GitGutterAll()
   endif
+  autocmd ColorScheme * call s:define_sign_column_highlight() | call s:define_highlights()
 augroup END
 
 " }}}


### PR DESCRIPTION
When colorscheme changed, gitgutter's highlight does not work. Because ordinary colorschemes execute `hi clear` initially, highlight definitions (e.g. `GitGutterAdd`) are cleared.

This pull request fixes this problem to use `autocmd ColorScheme`.
Thanks.
