### PR TITLE
Prevent error message from showing when s:dummy_sign_id is not set

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -392,7 +392,9 @@ function! s:add_dummy_sign()
 endfunction
 
 function! s:remove_dummy_sign()
-  exe ":sign unplace" s:dummy_sign_id "file=" . s:file()
+  if exists('s:dummy_sign_id')
+    exe ":sign unplace" s:dummy_sign_id "file=" . s:file()
+  endif
 endfunction
 
 " }}}


### PR DESCRIPTION
I'm calling `:GitGutterEnable` and `:GitGutterDisable` as part of another toggle function that also shows/hides line numbers. An issue came up when it would call `:GitGutterDisable` on a file that wasn't in a git repository.

`E121: Undefined variable: s:dummy_sign_id`
`E15: Invalid expression: s:dummy_sign_id "file=" . s:file()`

This change checks to see if `s:dummy_sign_id` exists before it removes it.
