### PR TITLE
Replace cd with pushd,

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -108,7 +108,7 @@ function! s:discard_stdout_and_stderr()
 endfunction
 
 function! s:command_in_directory_of_file(cmd)
-  let s:cmd_in_dir = 'cd ' . s:directory_of_file() . ' && ' . a:cmd
+  let s:cmd_in_dir = 'pushd ' . s:directory_of_file() . ' && ' . a:cmd
   return substitute(s:cmd_in_dir, "'", '"', 'g')
 endfunction
 


### PR DESCRIPTION
Error messages no longer appear for UNC paths.
Gutter still does not work for UNC paths.
#61
