### PR TITLE
Limit realtime update by the number of line

### DIFF
--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -101,6 +101,7 @@ You can customise:
 - Whether or not line highlighting is on initially (defaults to off)
 - Whether or not vim-gitgutter runs in realtime (defaults to yes)
 - Whether or not vim-gitgutter runs eagerly (defaults to yes)
+- Limit a realtime update by the number of line of a file (defaults to no limit)
 
 Please note that vim-gitgutter won't override any colours or highlights you've
 set in your colorscheme.
@@ -207,6 +208,14 @@ TO STOP VIM-GITGUTTER RUNNING IN REALTIME
 Add to your |vimrc|
 >
   let g:gitgutter_realtime = 0
+<
+
+TO LIMIT VIM-GITGUTTER RUNNING IN REALTIME BY THE NUMBER OF LINE
+
+To stop a realtime update when the number of line is more than 1000, add
+to your |vimrc|
+>
+  let g:gitgutter_realtime_line_limit = 1000
 <
 
 TO STOP VIM-GITGUTTER RUNNING EAGERLY

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -28,6 +28,7 @@ call s:set('g:gitgutter_sign_removed',          '_')
 call s:set('g:gitgutter_sign_modified_removed', '~_')
 call s:set('g:gitgutter_diff_args',             '')
 call s:set('g:gitgutter_escape_grep',           0)
+call s:set('g:gitgutter_realtime_line_limit',   0)
 
 let s:file = ''
 let s:hunk_summary = [0, 0, 0]
@@ -584,7 +585,7 @@ augroup gitgutter
   autocmd!
 
   if g:gitgutter_realtime
-    autocmd CursorHold,CursorHoldI * call GitGutter(s:current_file(), 1)
+    autocmd CursorHold,CursorHoldI * if line('$') > g:gitgutter_realtime_line_limit | call GitGutter(s:current_file(), 1) | endif
   endif
 
   if g:gitgutter_eager


### PR DESCRIPTION
When I edited a large file, it took much time to redraw signs. I wanted to disable realtime update when I edited a large file.
So I added `g:gitgutter_realtime_line_limit`. If the number of the file is more than this variable, realtime update is disabled. Because the default value of `g:gitgutter_realtime_line_limit` is `0`, this variable doesn't make a change as default.
