### PR TITLE
Clear out hunk stats when file is not tracked.

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -466,6 +466,8 @@ function! GitGutter(file, ...)
     call s:clear_signs(a:file)
     call s:find_other_signs(a:file)
     call s:show_signs(a:file, modified_lines)
+  else
+    let s:hunk_summary = [-1, -1, -1]
   endif
 endfunction
 command GitGutter call GitGutter(s:current_file())


### PR DESCRIPTION
hello, here's a minor bug fix for https://github.com/bling/vim-airline/issues/227 to clear out the stats when opening an untracked file.  thanks.
