### PR TITLE
Fix GitGutter argument errors on save and toggle.

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -94,7 +94,7 @@ command GitGutterDisable call GitGutterDisable()
 
 function! GitGutterEnable()
   let g:gitgutter_enabled = 1
-  call GitGutter(utility#current_file())
+  call GitGutter(utility#current_file(), 0, 0)
 endfunction
 command GitGutterEnable call GitGutterEnable()
 
@@ -219,7 +219,7 @@ augroup gitgutter
       autocmd FocusGained * call GitGutterAll()
     endif
   else
-    autocmd BufRead,BufWritePost,FileChangedShellPost * call GitGutter(utility#current_file())
+    autocmd BufRead,BufWritePost,FileChangedShellPost * call GitGutter(utility#current_file(), 0, 0)
   endif
 
   autocmd ColorScheme * call highlight#define_sign_column_highlight() | call highlight#define_highlights()


### PR DESCRIPTION
Just updated to master and it looks like a regression was introduced in d420a445363bef98dc50fd622c5c96b202abd605 when toggling and saving
![screen shot 2014-01-07 at 12 21 20 pm](https://f.cloud.github.com/assets/885841/1862945/ba83cafc-77d9-11e3-9c8a-3fcb3c9cdebe.png)
This commit fixes it
