### PR TITLE
Add parens around diff command

### DIFF
--- a/autoload/diff.vim
+++ b/autoload/diff.vim
@@ -4,7 +4,7 @@ let s:hunk_re = '^@@ -\(\d\+\),\?\(\d*\) +\(\d\+\),\?\(\d*\) @@'
 
 
 function! diff#run_diff(realtime, use_external_grep)
-  let cmd = 'git ls-files --error-unmatch ' . utility#shellescape(utility#file()) . ' && ('
+  let cmd = '(git ls-files --error-unmatch ' . utility#shellescape(utility#file()) . ' && ('
 
   if a:realtime
     let blob_name = ':' . utility#shellescape(utility#file_relative_to_repo_root())
@@ -22,7 +22,7 @@ function! diff#run_diff(realtime, use_external_grep)
     let cmd .= s:grep_command . ' || true'
   endif
 
-  let cmd .= ')'
+  let cmd .= '))'
 
   if a:realtime
     let diff = system(utility#command_in_directory_of_file(cmd), utility#buffer_contents())


### PR DESCRIPTION
This corrects issues on my system where non-tracked files cause a fatal
error on load.

Update #137 on Github
