### PR TITLE
Use bg values from SignColumn for GitGutter{Add,Change,Delete}Default

### DIFF
--- a/autoload/highlight.vim
+++ b/autoload/highlight.vim
@@ -3,16 +3,12 @@ function! highlight#define_sign_column_highlight()
 endfunction
 
 function! highlight#define_highlights()
-  redir => sign_highlight
-  silent highlight SignColumn
-  redir END
-  let sign_ctermbg = matchlist(sign_highlight, 'ctermbg=\(\S\+\)')[1]
-  let sign_guibg   = matchlist(sign_highlight,   'guibg=\(\S\+\)')[1]
+  let [guibg, ctermbg] = highlight#get_background_colors('SignColumn')
 
   " Highlights used by the signs.
-  execute "highlight GitGutterAddDefault    guifg=#009900 guibg=".sign_guibg." ctermfg=2 ctermbg=".sign_ctermbg
-  execute "highlight GitGutterChangeDefault guifg=#bbbb00 guibg=".sign_guibg." ctermfg=3 ctermbg=".sign_ctermbg
-  execute "highlight GitGutterDeleteDefault guifg=#ff2222 guibg=".sign_guibg." ctermfg=1 ctermbg=".sign_ctermbg
+  execute "highlight GitGutterAddDefault    guifg=#009900 guibg=" . guibg . " ctermfg=2 ctermbg=" . ctermbg
+  execute "highlight GitGutterChangeDefault guifg=#bbbb00 guibg=" . guibg . " ctermfg=3 ctermbg=" . ctermbg
+  execute "highlight GitGutterDeleteDefault guifg=#ff2222 guibg=" . guibg . " ctermfg=1 ctermbg=" . ctermbg
   highlight default link GitGutterChangeDeleteDefault GitGutterChangeDefault
 
   highlight default link GitGutterAdd          GitGutterAddDefault
@@ -65,4 +61,27 @@ function! highlight#define_sign_line_highlights()
     sign define GitGutterLineRemoved         linehl=
     sign define GitGutterLineModifiedRemoved linehl=
   endif
+endfunction
+
+function! highlight#get_background_colors(group)
+  redir => highlight
+  silent execute 'silent highlight ' . a:group
+  redir END
+
+  let link_matches = matchlist(highlight, 'links to \(\S\+\)')
+  if len(link_matches) > 0 " follow the link
+    return highlight#get_background_colors(link_matches[1])
+  endif
+
+  let ctermbg = highlight#match_highlight(highlight, 'ctermbg=\(\S\+\)')
+  let guibg   = highlight#match_highlight(highlight, 'guibg=\(\S\+\)')
+  return [guibg, ctermbg]
+endfunction
+
+function! highlight#match_highlight(highlight, pattern)
+  let matches = matchlist(a:highlight, a:pattern)
+  if len(matches) == 0
+    return 'NONE'
+  endif
+  return matches[1]
 endfunction


### PR DESCRIPTION
Previously you used `NONE` as `guibg` and `ctermbg` values for the `GitGutter{Add,Change,Delete}Default` highlight groups. Combined with color schemes that use a non-`NONE` background color for `SignColumn` they don't match:

![before](https://cloud.githubusercontent.com/assets/474504/2623890/093af524-bd0f-11e3-97e9-0f43919df5b7.png)

This pull requests reads the current background values from `SignColumn` and uses them instead:

![after](https://cloud.githubusercontent.com/assets/474504/2623893/2a3a526a-bd0f-11e3-97bf-b9a256684eaf.png)
