### PR TITLE
Fix 'Not possible to change sign ...' issue

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,5 +1,4 @@
-## vim-gitgutter
-
+aaaaa
 A Vim plugin which shows a git diff in the 'gutter' (sign column).  It shows whether each line has been added, modified, and where lines have been removed.  You can also stage and revert individual hunks.
 
 Features:

--- a/autoload/sign.vim
+++ b/autoload/sign.vim
@@ -147,10 +147,12 @@ function! sign#upsert_new_gitgutter_signs(file_name, modified_lines)
       if !has_key(old_gitgutter_signs, line_number)  " insert
         let id = sign#next_sign_id()
         " Vim cannot place sign to the line 0. It is happened when the user
-        " remove the first line of the file. Just ignore it.
-        if line_number != 0
-          execute "sign place" id "line=" . line_number "name=" . name "file=" . a:file_name
+        " remove the first line of the file.
+        " Instead of place sign at the line 0, place sign at the line 1.
+        if line_number == 0
+          let line_number = 1
         endif
+        execute "sign place" id "line=" . line_number "name=" . name "file=" . a:file_name
       else  " update if sign has changed
         let old_sign = old_gitgutter_signs[line_number]
         if old_sign.name !=# name


### PR DESCRIPTION
When user remove the first line of the file, vim-gitgutter tried to
replace the sign of the line 0 and the following error would caused.

```
Error detected while processing function
gitgutter#process_buffer..sign#update_sings..sign#upsert_new_gitgutter_signs:
line    13:
E885: Not possible to change sign GitGutterLineRemoved
```

While Vim does not have line 0, this commit simply ignore the sign
substitution when the specified line_number is 0.
