### PR TITLE
Fix 'Not possible to change sign ...' issue

### DIFF
--- a/autoload/sign.vim
+++ b/autoload/sign.vim
@@ -146,6 +146,12 @@ function! sign#upsert_new_gitgutter_signs(file_name, modified_lines)
       let name = utility#highlight_name_for_change(line[1])
       if !has_key(old_gitgutter_signs, line_number)  " insert
         let id = sign#next_sign_id()
+        " Vim cannot place sign to the line 0. It is happened when the user
+        " remove the first line of the file.
+        " Instead of place sign at the line 0, place sign at the line 1.
+        if line_number == 0
+          let line_number = 1
+        endif
         execute "sign place" id "line=" . line_number "name=" . name "file=" . a:file_name
       else  " update if sign has changed
         let old_sign = old_gitgutter_signs[line_number]


### PR DESCRIPTION
Sorry I put a stupid modification on #172 thus I rearrange the commits and request this pull.

When user remove the first line of the file, vim-gitgutter tried to
replace the sign of the line 0 and the following error would caused.

```
Error detected while processing function
gitgutter#process_buffer..sign#update_sings..sign#upsert_new_gitgutter_signs:
line    13:
E885: Not possible to change sign GitGutterLineRemoved
```

While Vim does not have line 0, place the sign at line 1 instead of line 0. 
It should be ok while if there are any modification at line 1, the sign will be overwritten with the correct one.

**The reproducing procedure is**
1. Open the file which is handled with git
2. Remove the first line and save it (No exception)
3. Close the Vim.
4. Reopen the file, it will cause the exception

Thanks.
