### PR TITLE
Fix glitches when updatetime is low

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -9,9 +9,14 @@ function! gitgutter#all()
   endfor
 endfunction
 
+let s:gitgutter_is_processing = 0
 " file: (string) the file to process.
 " realtime: (boolean) when truthy, do a realtime diff; otherwise do a disk-based diff.
 function! gitgutter#process_buffer(file, realtime)
+  if s:gitgutter_is_processing
+    return
+  endif
+  let s:gitgutter_is_processing = 1
   call utility#set_file(a:file)
   if utility#is_active()
     if g:gitgutter_sign_column_always
@@ -35,6 +40,7 @@ function! gitgutter#process_buffer(file, realtime)
   else
     call hunk#reset()
   endif
+  let s:gitgutter_is_processing = 0
 endfunction
 
 function! gitgutter#disable()


### PR DESCRIPTION
I have been able to reproduce the glitching problem (see #102) with this plugin consistently by setting `ut`(updatetime) to some low value. By default `ut` is set to 4000ms which doesn't cause any glitches, but some plugins may set it to a different value (for me it was [vim-css-color](http://github.com/skammer/vim-css-color) that did so). 

I have tested this with all other plugins disabled, and I was able to consistently trigger these glitches by setting ut to some low value (100 or lower did the trick for me) and typing relatively fast. This apparently causes `gitgutter#process_buffer` to be called in such rapid succession that a new call is already being done while the previous is still being processed.

Fortunately the fix seems relatively easy: by toggling a flag we can guarantee that `process_buffer` is never actually executed when the previous call has not yet returned. For me this fixed the issue.
