### PR TITLE
Reformat GitGutterGetHunkSummary's array

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -11,7 +11,11 @@ function! gitgutter#hunk#hunks()
 endfunction
 
 function! gitgutter#hunk#summary()
-  return s:summary
+  let s:result    = [0, 0, 0]
+  let s:result[0] = '+'.s:summary[0]
+  let s:result[1] = '~'.s:summary[1]
+  let s:result[2] = '-'.s:summary[2]
+  return s:result
 endfunction
 
 function! gitgutter#hunk#reset()


### PR DESCRIPTION
Update the array's format returned by GitGutterGetHunkSummary. 
From old format [0, 0, 0] into new format [+0, ~0, -0] to make it easier to understand when people integrate vim-gitgutter into vim-airline's status bar.

Before
![screen shot 2014-10-16 at 3 50 53 pm](https://cloud.githubusercontent.com/assets/3027146/4659831/9f351150-5511-11e4-97ad-2a52b9da2c8a.png)

After
![screen shot 2014-10-16 at 3 48 47 pm](https://cloud.githubusercontent.com/assets/3027146/4659838/ad9762fc-5511-11e4-932e-52276d0a5152.png)
