### PR TITLE
Use system() with silent to avoid visual artifact

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -107,7 +107,7 @@ function! gitgutter#utility#system(cmd, ...)
     let output = join(ret.stdout, "\n")
     let s:exit_code = ret.exit_code
   else
-    let output = (a:0 == 0) ? system(a:cmd) : system(a:cmd, a:1)
+    silent let output = (a:0 == 0) ? system(a:cmd) : system(a:cmd, a:1)
   endif
   return output
 endfunction


### PR DESCRIPTION
As mentioned in the README if we use an `updatetime` too low we could experience some glitches. To prevent this in recent version of vim [7.4.427](http://ftp.vim.org/vim/patches/7.4/7.4.427) every call to `system` should be done using `silent` if the command do not require the user input, as in the case of vim-gitgutter.
