### PR TITLE
Dealt with the case where the preview window is used by another plugin

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -196,9 +196,9 @@ function! gitgutter#preview_hunk()
     if !&previewwindow
       execute 'bo ' . &previewheight . ' new'
       set previewwindow
-      setlocal filetype=diff buftype=nofile bufhidden=delete noswapfile
     endif
 
+    setlocal noro modifiable filetype=diff buftype=nofile bufhidden=delete noswapfile
     execute "%delete_"
     call append(0, split(diff_for_hunk, "\n"))
 


### PR DESCRIPTION
I use fugitive a lot and there are times where I opened fugitive's preview window and then jumped to some part of the code trying to bring up the hulk previews for that particular part; where it fails because it's not able to reuse fugitive's preview window. I feel it's better to make it more generic like this so that the user doesn't have to close the preview window