### PR TITLE
Use a temporary file for buffer for realtime diffs

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -16,12 +16,19 @@ function! gitgutter#diff#run_diff(realtime, use_external_grep, lines_of_context)
   if a:realtime
     let blob_name = ':'.gitgutter#utility#shellescape(gitgutter#utility#file_relative_to_repo_root())
     let blob_file = tempname()
+    let buff_file = tempname()
+    let extension = gitgutter#utility#extension()
+    if !empty(extension)
+      let blob_file .= '.'.extension
+      let buff_file .= '.'.extension
+    endif
     let cmd .= 'git show '.blob_name.' > '.blob_file.' && '
+    execute('silent write '.buff_file)
   endif
 
   let cmd .= 'git diff --no-ext-diff --no-color -U'.a:lines_of_context.' '.g:gitgutter_diff_args.' -- '
   if a:realtime
-    let cmd .= blob_file.' - '
+    let cmd .= blob_file.' '.buff_file
   else
     let cmd .= gitgutter#utility#shellescape(gitgutter#utility#filename())
   endif
@@ -44,11 +51,11 @@ function! gitgutter#diff#run_diff(realtime, use_external_grep, lines_of_context)
     let cmd .= ')'
   endif
 
+  let diff = gitgutter#utility#system(gitgutter#utility#command_in_directory_of_file(cmd))
+
   if a:realtime
-    let diff = gitgutter#utility#system(gitgutter#utility#command_in_directory_of_file(cmd), gitgutter#utility#buffer_contents())
     call delete(blob_file)
-  else
-    let diff = gitgutter#utility#system(gitgutter#utility#command_in_directory_of_file(cmd))
+    call delete(buff_file)
   endif
 
   if gitgutter#utility#shell_error()

--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -46,6 +46,7 @@ function! gitgutter#diff#run_diff(realtime, use_external_grep, lines_of_context)
 
   if a:realtime
     let diff = gitgutter#utility#system(gitgutter#utility#command_in_directory_of_file(cmd), gitgutter#utility#buffer_contents())
+    call delete(blob_file)
   else
     let diff = gitgutter#utility#system(gitgutter#utility#command_in_directory_of_file(cmd))
   endif

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -71,17 +71,6 @@ function! gitgutter#utility#save_last_seen_change()
   call setbufvar(s:bufnr, 'gitgutter_last_tick', getbufvar(s:bufnr, 'changedtick'))
 endfunction
 
-function! gitgutter#utility#buffer_contents()
-  if &fileformat ==# "dos"
-    let eol = "\r\n"
-  elseif &fileformat ==# "mac"
-    let eol = "\r"
-  else
-    let eol = "\n"
-  endif
-  return join(getbufline(s:bufnr, 1, '$'), eol) . eol
-endfunction
-
 function! gitgutter#utility#shell_error()
   return gitgutter#utility#using_xolox_shell() ? s:exit_code : v:shell_error
 endfunction

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -47,6 +47,10 @@ function! gitgutter#utility#filename()
   return fnamemodify(s:file, ':t')
 endfunction
 
+function! gitgutter#utility#extension()
+  return fnamemodify(s:file, ':e')
+endfunction
+
 function! gitgutter#utility#directory_of_file()
   return fnamemodify(s:file, ':h')
 endfunction


### PR DESCRIPTION
`git diff` doesn't perform EOL conversion on stdin, causing it to mistakenly flag every line as having changed when the working tree uses a different EOL than the blobs. Writing the buffer to a temporary file and diffing against that avoids this issue.  This PR also deletes the temporary blob file created for realtime diffs.

Fixes #232.