### PR TITLE
Don't use --color if grep doesn't support it

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -1,5 +1,12 @@
 let s:grep_available = executable('grep')
-let s:grep_command = ' | '.(g:gitgutter_escape_grep ? '\grep' : 'grep').' --color=never -e '.gitgutter#utility#shellescape('^@@ ')
+if s:grep_available
+  let s:grep_command = ' | '.(g:gitgutter_escape_grep ? '\grep' : 'grep')
+  let s:grep_help = gitgutter#utility#system('grep --help')
+  if s:grep_help =~# '--color'
+    let s:grep_command .= ' --color=never'
+  endif
+  let s:grep_command .= ' -e '.gitgutter#utility#shellescape('^@@ ')
+endif
 let s:hunk_re = '^@@ -\(\d\+\),\?\(\d*\) +\(\d\+\),\?\(\d*\) @@'
 
 


### PR DESCRIPTION
Not all versions of grep support the `--color` flag. This checks the output of `grep --help` when building the grep command and avoids using flags that aren't compatible with the version present.

Fixes #234.