### PR TITLE
Provide a way to see staged changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /doc/tags
 /misc
 /test/*.actual
+/test/*.logvim

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -252,17 +252,6 @@ endfunction
 " Staged {{{
 function! gitgutter#staged_enable()
 
-  " Don't clobber the saved signs
-  if !g:gitgutter_staged
-    let g:gitgutter_sign_added_original = g:gitgutter_sign_added
-    let g:gitgutter_sign_modified_original = g:gitgutter_sign_modified
-    let g:gitgutter_sign_removed_original = g:gitgutter_sign_removed
-  endif
-
-  let g:gitgutter_sign_added = g:gitgutter_sign_staged_added
-  let g:gitgutter_sign_modified = g:gitgutter_sign_staged_modified
-  let g:gitgutter_sign_removed = g:gitgutter_sign_staged_removed
-
   let g:gitgutter_staged = 1
   call gitgutter#highlight#define_signs()
 
@@ -270,13 +259,6 @@ function! gitgutter#staged_enable()
 endfunction
 
 function! gitgutter#staged_disable()
-
-  " Signs
-  if g:gitgutter_staged
-    let g:gitgutter_sign_added = g:gitgutter_sign_added_original
-    let g:gitgutter_sign_modified = g:gitgutter_sign_modified_original
-    let g:gitgutter_sign_removed = g:gitgutter_sign_removed_original
-  endif
 
   let g:gitgutter_staged = 0
   call gitgutter#highlight#define_signs()

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -241,6 +241,10 @@ function! gitgutter#preview_hunk()
       setlocal noro modifiable filetype=diff buftype=nofile bufhidden=delete noswapfile
       execute "%delete_"
       call append(0, split(diff_for_hunk, "\n"))
+      " Delete the last, empty line
+      if empty(getline('$'))
+        execute '$delete_'
+      endif
 
       wincmd p
     endif

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -19,9 +19,30 @@ function! gitgutter#process_buffer(bufnr, realtime)
     endif
     try
       if !a:realtime || gitgutter#utility#has_fresh_changes()
-        let diff = gitgutter#diff#run_diff(a:realtime || gitgutter#utility#has_unsaved_changes(), 1)
-        call gitgutter#hunk#set_hunks(gitgutter#diff#parse_diff(diff))
-        let modified_lines = gitgutter#diff#process_hunks(gitgutter#hunk#hunks())
+        if g:gitgutter_staged
+          let diff_head  = gitgutter#diff#run_diff_revision(a:realtime || gitgutter#utility#has_unsaved_changes(), 1, 'HEAD')
+          let diff_index = gitgutter#diff#run_diff_revision(a:realtime || gitgutter#utility#has_unsaved_changes(), 1, '')
+          let hunks_head  = gitgutter#diff#parse_diff(diff_head)
+          let hunks_index = gitgutter#diff#parse_diff(diff_index)
+          " Remove the non-staged hunks
+          let current_hunks = filter(copy(hunks_head), 'index(hunks_index,v:val) == -1')
+
+          " TODO: Set the correct hunks
+          " call gitgutter#hunk#set_hunks()
+          let processed_head = gitgutter#diff#process_hunks(hunks_head)
+          let processed_index = gitgutter#diff#process_hunks(hunks_index)
+          let modified_lines = filter(copy(processed_head), 'index(processed_index,v:val) == -1')
+          if &verbose
+            echom 'P_H:'.string(processed_head)
+            echom 'P_I:'.string(processed_index)
+            echom 'RES:'.string(modified_lines)
+          endif
+        else
+          let diff = gitgutter#diff#run_diff(a:realtime || gitgutter#utility#has_unsaved_changes(), 1)
+          let current_hunks = gitgutter#diff#parse_diff(diff)
+          call gitgutter#hunk#set_hunks(current_hunks)
+          let modified_lines = gitgutter#diff#process_hunks(gitgutter#hunk#hunks())
+        endif
 
         if len(modified_lines) > g:gitgutter_max_signs
           call gitgutter#utility#warn_once('exceeded maximum number of signs (configured by g:gitgutter_max_signs).', 'max_signs')
@@ -151,6 +172,10 @@ endfunction
 " Hunks {{{
 
 function! gitgutter#stage_hunk()
+  if g:gitgutter_staged
+    call gitgutter#utility#warn('Unsupported')
+    return
+  endif
   if gitgutter#utility#is_active()
     " Ensure the working copy of the file is up to date.
     " It doesn't make sense to stage a hunk otherwise.
@@ -171,6 +196,10 @@ function! gitgutter#stage_hunk()
 endfunction
 
 function! gitgutter#revert_hunk()
+  if g:gitgutter_staged
+    call gitgutter#utility#warn('Unsupported')
+    return
+  endif
   if gitgutter#utility#is_active()
     " Ensure the working copy of the file is up to date.
     " It doesn't make sense to stage a hunk otherwise.
@@ -191,6 +220,10 @@ function! gitgutter#revert_hunk()
 endfunction
 
 function! gitgutter#preview_hunk()
+  if g:gitgutter_staged
+    call gitgutter#utility#warn('Unsupported')
+    return
+  endif
   if gitgutter#utility#is_active()
     silent write
 
@@ -214,4 +247,48 @@ function! gitgutter#preview_hunk()
   endif
 endfunction
 
+" }}}
+
+" Staged {{{
+function! gitgutter#staged_enable()
+
+  " Don't clobber the saved signs
+  if !g:gitgutter_staged
+    let g:gitgutter_sign_added_original = g:gitgutter_sign_added
+    let g:gitgutter_sign_modified_original = g:gitgutter_sign_modified
+    let g:gitgutter_sign_removed_original = g:gitgutter_sign_removed
+  endif
+
+  let g:gitgutter_sign_added = g:gitgutter_sign_staged_added
+  let g:gitgutter_sign_modified = g:gitgutter_sign_staged_modified
+  let g:gitgutter_sign_removed = g:gitgutter_sign_staged_removed
+
+  let g:gitgutter_staged = 1
+  call gitgutter#highlight#define_signs()
+
+  call gitgutter#all()
+endfunction
+
+function! gitgutter#staged_disable()
+
+  " Signs
+  if g:gitgutter_staged
+    let g:gitgutter_sign_added = g:gitgutter_sign_added_original
+    let g:gitgutter_sign_modified = g:gitgutter_sign_modified_original
+    let g:gitgutter_sign_removed = g:gitgutter_sign_removed_original
+  endif
+
+  let g:gitgutter_staged = 0
+  call gitgutter#highlight#define_signs()
+
+  call gitgutter#all()
+endfunction
+
+function! gitgutter#staged_toggle()
+  if g:gitgutter_staged
+    call gitgutter#staged_disable()
+  else
+    call gitgutter#staged_enable()
+  endif
+endfunction
 " }}}

--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -54,10 +54,22 @@ let s:temp_buffer = tempname()
 " You can use the sister function to run a diff against a specific revision
 " (git interprets this, so it can be a tag, a branch, an hash, anything).
 " If the revision is an empty string, the diff is run against the index.
+"
+" You can also use the "staged" function to run a diff against the index. This
+" is equivalent to:
+"
+"      git diff --staged
+"
 function! gitgutter#diff#run_diff(realtime, use_external_grep)
-  return gitgutter#diff#run_diff_revision(a:realtime, a:use_external_grep, '')
+  return s:run_diff(a:realtime, a:use_external_grep, '', 0)
 endfunction
 function! gitgutter#diff#run_diff_revision(realtime, use_external_grep, revision)
+  return s:run_diff(a:realtime, a:use_external_grep, a:revision, 0)
+endfunction
+function! gitgutter#diff#run_diff_staged(realtime, use_external_grep)
+  return s:run_diff(a:realtime, a:use_external_grep, '', 1)
+endfunction
+function! s:run_diff(realtime, use_external_grep, revision, staged)
   " Wrap compound commands in parentheses to make Windows happy.
   " bash doesn't mind the parentheses; fish doesn't want them.
   let cmd = s:fish ? '' : '('
@@ -96,14 +108,18 @@ function! gitgutter#diff#run_diff_revision(realtime, use_external_grep, revision
   endif
 
   let cmd .= 'git -c "diff.autorefreshindex=0" diff --no-ext-diff --no-color -U0 '.g:gitgutter_diff_args
-  if !a:realtime
-    let cmd .= ' '.a:revision.' '
-  endif
-  let cmd .= ' -- '
-  if a:realtime
-    let cmd .= blob_file.' '.buff_file
+  if a:staged
+    let cmd .= ' --staged '
   else
-    let cmd .= gitgutter#utility#shellescape(gitgutter#utility#filename())
+    if !a:realtime
+      let cmd .= ' '.a:revision.' '
+    endif
+    let cmd .= ' -- '
+    if a:realtime
+      let cmd .= blob_file.' '.buff_file
+    else
+      let cmd .= gitgutter#utility#shellescape(gitgutter#utility#filename())
+    endif
   endif
 
   if a:use_external_grep && s:grep_available
@@ -287,9 +303,14 @@ endfunction
 "
 " type - stage | revert | preview
 function! gitgutter#diff#generate_diff_for_hunk(type)
+  " By default, generate diffs with "staged" == FALSE
+  return gitgutter#diff#generate_diff_for_hunk_internal(a:type, 0)
+endfunction
+function! gitgutter#diff#generate_diff_for_hunk_internal(type, staged)
+  let l:staged = a:staged ? '_staged' : ''
   " Although (we assume) diff is up to date, we don't store it anywhere so we
   " have to regenerate it now...
-  let diff = gitgutter#diff#run_diff(0, 0)
+  let diff = gitgutter#diff#run_diff{l:staged}(0, 0)
   let diff_for_hunk = gitgutter#diff#discard_hunks(diff, a:type == 'stage' || a:type == 'revert')
 
   if a:type == 'stage' || a:type == 'revert'

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -48,11 +48,12 @@ function! gitgutter#highlight#define_signs()
 endfunction
 
 function! gitgutter#highlight#define_sign_text()
-  execute "sign define GitGutterLineAdded            text=" . g:gitgutter_sign_added
-  execute "sign define GitGutterLineModified         text=" . g:gitgutter_sign_modified
-  execute "sign define GitGutterLineRemoved          text=" . g:gitgutter_sign_removed
-  execute "sign define GitGutterLineRemovedFirstLine text=" . g:gitgutter_sign_removed_first_line
-  execute "sign define GitGutterLineModifiedRemoved  text=" . g:gitgutter_sign_modified_removed
+  let l:staged = g:gitgutter_staged ? 'staged_' : ''
+  execute "sign define GitGutterLineAdded            text=" . g:gitgutter_sign_{l:staged}added
+  execute "sign define GitGutterLineModified         text=" . g:gitgutter_sign_{l:staged}modified
+  execute "sign define GitGutterLineRemoved          text=" . g:gitgutter_sign_{l:staged}removed
+  execute "sign define GitGutterLineRemovedFirstLine text=" . g:gitgutter_sign_{l:staged}removed_first_line
+  execute "sign define GitGutterLineModifiedRemoved  text=" . g:gitgutter_sign_{l:staged}modified_removed
 endfunction
 
 function! gitgutter#highlight#define_sign_text_highlights()

--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -31,6 +31,10 @@ function! gitgutter#hunk#increment_lines_removed(count)
 endfunction
 
 function! gitgutter#hunk#next_hunk(count)
+  if g:gitgutter_staged
+    call gitgutter#utility#warn('Unsupported')
+    return
+  endif
   if gitgutter#utility#is_active()
     let current_line = line('.')
     let hunk_count = 0
@@ -48,6 +52,10 @@ function! gitgutter#hunk#next_hunk(count)
 endfunction
 
 function! gitgutter#hunk#prev_hunk(count)
+  if g:gitgutter_staged
+    call gitgutter#utility#warn('Unsupported')
+    return
+  endif
   if gitgutter#utility#is_active()
     let current_line = line('.')
     let hunk_count = 0

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -44,10 +44,14 @@ catch /E239/
   let g:gitgutter_sign_removed_first_line = '_^'
 endtry
 
-call s:set('g:gitgutter_sign_modified_removed',    '~_')
-call s:set('g:gitgutter_diff_args',                  '')
-call s:set('g:gitgutter_map_keys',                    1)
-call s:set('g:gitgutter_avoid_cmd_prompt_on_windows', 1)
+call s:set('g:gitgutter_sign_modified_removed',      '~_')
+call s:set('g:gitgutter_diff_args',                    '')
+call s:set('g:gitgutter_map_keys',                      1)
+call s:set('g:gitgutter_avoid_cmd_prompt_on_windows',   1)
+call s:set('g:gitgutter_staged',                        0)
+call s:set('g:gitgutter_sign_staged_added',           'A')
+call s:set('g:gitgutter_sign_staged_modified',        'M')
+call s:set('g:gitgutter_sign_staged_removed',         'R')
 
 call gitgutter#highlight#define_sign_column_highlight()
 call gitgutter#highlight#define_highlights()
@@ -121,6 +125,14 @@ endfunction
 
 " }}}
 
+" Staged {{{
+
+command GitGutterStagedDisable call gitgutter#staged_disable()
+command GitGutterStagedEnable call gitgutter#staged_enable()
+command GitGutterStagedToggle  call gitgutter#staged_toggle()
+
+" }}}
+
 command -bar GitGutterDebug call gitgutter#debug#debug()
 
 " Maps {{{
@@ -141,6 +153,7 @@ endif
 nnoremap <silent> <Plug>GitGutterStageHunk   :GitGutterStageHunk<CR>
 nnoremap <silent> <Plug>GitGutterRevertHunk  :GitGutterRevertHunk<CR>
 nnoremap <silent> <Plug>GitGutterPreviewHunk :GitGutterPreviewHunk<CR>
+nnoremap <silent> <Plug>GitGutterStagedToggle :GitGutterStagedToggle<CR>
 
 if g:gitgutter_map_keys
   if !hasmapto('<Plug>GitGutterStageHunk') && maparg('<Leader>hs', 'n') ==# ''
@@ -151,6 +164,9 @@ if g:gitgutter_map_keys
   endif
   if !hasmapto('<Plug>GitGutterPreviewHunk') && maparg('<Leader>hp', 'n') ==# ''
     nmap <Leader>hp <Plug>GitGutterPreviewHunk
+  endif
+  if !hasmapto('<Plug>GitGutterStagedToggle') && maparg('<Leader>hc', 'n') ==# ''
+    nmap <Leader>hc <Plug>GitGutterStagedToggle
   endif
 endif
 

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -35,6 +35,11 @@ call s:set('g:gitgutter_sign_column_always',          0)
 call s:set('g:gitgutter_override_sign_column_highlight', 1)
 call s:set('g:gitgutter_realtime',                    1)
 call s:set('g:gitgutter_eager',                       1)
+call s:set('g:gitgutter_diff_args',                    '')
+call s:set('g:gitgutter_map_keys',                      1)
+call s:set('g:gitgutter_avoid_cmd_prompt_on_windows',   1)
+call s:set('g:gitgutter_staged',                        0)
+" Signs
 call s:set('g:gitgutter_sign_added',                '+')
 call s:set('g:gitgutter_sign_modified',             '~')
 call s:set('g:gitgutter_sign_removed',              '_')
@@ -43,15 +48,17 @@ try
 catch /E239/
   let g:gitgutter_sign_removed_first_line = '_^'
 endtry
-
 call s:set('g:gitgutter_sign_modified_removed',      '~_')
-call s:set('g:gitgutter_diff_args',                    '')
-call s:set('g:gitgutter_map_keys',                      1)
-call s:set('g:gitgutter_avoid_cmd_prompt_on_windows',   1)
-call s:set('g:gitgutter_staged',                        0)
-call s:set('g:gitgutter_sign_staged_added',           'A')
-call s:set('g:gitgutter_sign_staged_modified',        'M')
-call s:set('g:gitgutter_sign_staged_removed',         'R')
+
+call s:set('g:gitgutter_sign_staged_added',                'A')
+call s:set('g:gitgutter_sign_staged_modified',             'M')
+call s:set('g:gitgutter_sign_staged_removed',              'R')
+try
+  call s:set('g:gitgutter_sign_staged_removed_first_line', 'Я')
+catch /E239/
+  let g:gitgutter_sign_staged_removed_first_line = '^_'
+endtry
+call s:set('g:gitgutter_sign_staged_modified_removed',      'MR')
 
 call gitgutter#highlight#define_sign_column_highlight()
 call gitgutter#highlight#define_highlights()

--- a/test/staged.expected
+++ b/test/staged.expected
@@ -1,0 +1,4 @@
+
+--- Signs ---
+Signs for fixture.txt:
+    line=7  id=3001  name=GitGutterLineAdded

--- a/test/test
+++ b/test/test
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 
-VIM="/Applications/MacVim.app/Contents/MacOS/Vim -v"
+if [ -z "$VIM" ]; then
+  VIM="/Applications/MacVim.app/Contents/MacOS/Vim -v"
+fi
 
 # Execute the tests.
 for testcase in test*.vim; do
-  $VIM -N -u NONE -S $testcase -c 'quit!'
+  vimout="$testcase".logvim
+
+  if [ -f "$vimout" ]; then
+    # Start the log from scratch
+    rm "$vimout"
+  fi
+
+  $VIM -N -u NONE -c 'set verbosefile='"$vimout" -S "$testcase" -c 'quit!'
 
   git reset HEAD fixture.txt > /dev/null
   git checkout fixture.txt

--- a/test/testStaged.vim
+++ b/test/testStaged.vim
@@ -1,0 +1,15 @@
+source helper.vim
+call Setup()
+
+" New hunk in the middle of the file
+normal 5Go*
+" Stage that hunk
+execute 'GitGutterStageHunk'
+" Add non-staged hunks
+normal ggo*
+normal GO*
+" Switch to Staged mode
+execute 'GitGutterStagedEnable'
+
+" Should have a single staged hunk
+call DumpSigns('staged')


### PR DESCRIPTION
As referenced in #249 and #252.

This addition is disabled by default, per the `g:gitgutter_cached` variable. Well, unless it runs the `gitgutter#cached_enable` function is disabled anyway. How can I fix this?

The defaults are as follows:
- 'A' for staged additions
- 'M' for staged modification
- 'R' for staged removals
- '-M --cached' as the default diff arguments
  All this can be overridden just like the rest of the plugin.

It defines a new mapping '\hc' that toggles between the default
configuration and staged mode.

The option for running `git diff` twice and juggle all markers is left as an exercise to the reader.
