### PR TITLE
Wipeout temporary buffer created when writing file to diff

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -75,6 +75,7 @@ function! gitgutter#diff#run_diff(realtime, use_external_grep)
   if a:realtime
     call delete(blob_file)
     call delete(buff_file)
+    execute 'keepalt silent! bwipeout' buff_file
   endif
 
   if gitgutter#utility#shell_error()


### PR DESCRIPTION
This avoids creating a ton of dead buffers that slow down plugins that
iterate over all buffers, such as YouCompleteMe.