### PR TITLE
Make sign line filter expression more specific

### DIFF
--- a/autoload/gitgutter/sign.vim
+++ b/autoload/gitgutter/sign.vim
@@ -77,7 +77,7 @@ function! gitgutter#sign#find_current_signs()
     silent execute "sign place buffer=" . bufnr
   redir END
 
-  for sign_line in filter(split(signs, '\n'), 'v:val =~# "="')
+  for sign_line in filter(split(signs, '\n'), 'v:val =~# "line=[0-9]\+ id=[0-9]\+ name="')
     " Typical sign line:  line=88 id=1234 name=GitGutterLineAdded
     " We assume splitting is faster than a regexp.
     let components  = split(sign_line)


### PR DESCRIPTION
With previous expression, setting verbose>=15 
(which prints each line before it’s executed)
results in an exception because the “signs”
variable now includes the text of line 77, thus 
passing the filter. When the “name” variable 
assignment is then attempted, “components[2]”
contains no ‘=‘ signs and hence trying to access 
the second element of “split(components[2], ‘=‘)” 
results in an out-of-bounds exception (E684).
