### PR TITLE
Specify help files correctly

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -13,15 +13,15 @@ endfunction
 " Returns truthy when the buffer's file should be processed; and falsey when it shouldn't.
 " This function does not and should not make any system calls.
 function! gitgutter#utility#is_active()
-  return g:gitgutter_enabled && gitgutter#utility#exists_file() && gitgutter#utility#not_git_dir() && gitgutter#utility#not_help_file()
+  return g:gitgutter_enabled && gitgutter#utility#exists_file() && gitgutter#utility#not_git_dir() && !gitgutter#utility#help_file()
 endfunction
 
 function! gitgutter#utility#not_git_dir()
   return gitgutter#utility#full_path_to_directory_of_file() !~ '[/\\]\.git\($\|[/\\]\)'
 endfunction
 
-function! gitgutter#utility#not_help_file()
-  return getbufvar(s:bufnr, '&filetype') != 'help'
+function! gitgutter#utility#help_file()
+  return getbufvar(s:bufnr, '&filetype') ==# 'help' && getbufvar(s:bufnr, '&buftype') ==# 'help'
 endfunction
 
 " A replacement for the built-in `shellescape(arg)`.


### PR DESCRIPTION
This makes so that editing helpfiles directly triggers the gutters,
while keeping the default behaviour of editing help buffers (opened
with `:help stuff`) doesn't.