### PR TITLE
Use git diff-files instead of git diff

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -49,7 +49,7 @@ function! gitgutter#diff#run_diff(realtime, use_external_grep)
     call setpos("']", op_mark_end)
   endif
 
-  let cmd .= 'git diff --no-ext-diff --no-color -U0 '.g:gitgutter_diff_args.' -- '
+  let cmd .= 'git -c "diff.autorefreshindex=0" diff --no-ext-diff --no-color -U0 '.g:gitgutter_diff_args.' -- '
   if a:realtime
     let cmd .= blob_file.' '.buff_file
   else


### PR DESCRIPTION
This improves performance on huge repositories. I didn't investigate what precisely is going on but it *seems* that `git diff` sometimes (e.g. when reverting all the changes in a file) causes index update which freezes vim. Reproducible by running in shell: `touch somefile && git diff -- somefile`. Running `git diff-files` instead avoids the freeze.

I'm not aware of any negative implications of the change: used it for a couple of month without spotting buggy behaviour.