### PR TITLE
make it possible to wrap around with GitGutter{Prev,Next}Hunk

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -34,16 +34,23 @@ function! gitgutter#hunk#next_hunk(count)
   if gitgutter#utility#is_active()
     let current_line = line('.')
     let hunk_count = 0
-    for hunk in s:hunks
-      if hunk[2] > current_line
-        let hunk_count += 1
-        if hunk_count == a:count
-          execute 'normal!' hunk[2] . 'G'
-          return
+    let use_circular_hunks = g:gitgutter_circular_hunks && len(s:hunks)
+    while 1
+      for hunk in s:hunks
+        if hunk[2] > current_line
+          let hunk_count += 1
+          if hunk_count == a:count
+            execute 'normal!' hunk[2] . 'G'
+            return
+          endif
         endif
+      endfor
+      if !use_circular_hunks
+        call gitgutter#utility#warn('No more hunks')
+        return
       endif
-    endfor
-    call gitgutter#utility#warn('No more hunks')
+      let current_line = 0
+    endwhile
   endif
 endfunction
 
@@ -51,17 +58,24 @@ function! gitgutter#hunk#prev_hunk(count)
   if gitgutter#utility#is_active()
     let current_line = line('.')
     let hunk_count = 0
-    for hunk in reverse(copy(s:hunks))
-      if hunk[2] < current_line
-        let hunk_count += 1
-        if hunk_count == a:count
-          let target = hunk[2] == 0 ? 1 : hunk[2]
-          execute 'normal!' target . 'G'
-          return
+    let use_circular_hunks = g:gitgutter_circular_hunks && len(s:hunks)
+    while 1
+      for hunk in reverse(copy(s:hunks))
+        if hunk[2] < current_line
+          let hunk_count += 1
+          if hunk_count == a:count
+            let target = hunk[2] == 0 ? 1 : hunk[2]
+            execute 'normal!' target . 'G'
+            return
+          endif
         endif
+      endfor
+      if !use_circular_hunks
+        call gitgutter#utility#warn('No previous hunks')
+        return
       endif
-    endfor
-    call gitgutter#utility#warn('No previous hunks')
+      let current_line = line('$') + 1
+    endwhile
   endif
 endfunction
 

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -257,6 +257,12 @@ Add to your |vimrc|
   let g:gitgutter_eager = 0
 <
 
+TO USE CIRCULAR HUNKS
+
+To jump among the hunks circularly, add to your |vimrc|
+>
+  let g:gitgutter_circular_hunks = 1
+<
 
 ===============================================================================
 6. FAQ                                                           *GitGutterFAQ*

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -49,6 +49,7 @@ call s:set('g:gitgutter_diff_args',                  '')
 call s:set('g:gitgutter_escape_grep',                 0)
 call s:set('g:gitgutter_map_keys',                    1)
 call s:set('g:gitgutter_avoid_cmd_prompt_on_windows', 1)
+call s:set('g:gitgutter_circular_hunks',              0)
 
 call gitgutter#highlight#define_sign_column_highlight()
 call gitgutter#highlight#define_highlights()


### PR DESCRIPTION
For issue https://github.com/airblade/vim-gitgutter/issues/260
Add a new option `g:gitgutter_circular_hunks` to configure if GitGutter{Prev,Next}Hunk will wrap around.