### PR TITLE
Support custom grep command (reduces startup time when configured)

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -273,10 +273,10 @@ let g:gitgutter_escape_grep = 1
 
 #### Use a custom `grep` command
 
-If you use an alternative to grep, you can tell vim-gitgutter to use it here.
+If you use an alternative to grep, you can tell vim-gitgutter to use it here. It only needs to support extended POSIX regex.
 
 ```viml
-let g:gitgutter_grep_command = ' | grep --color=never -e "^@@"'
+let g:gitgutter_grep_command = 'grep --color=never -e'
 ```
 
 #### To turn off vim-gitgutter by default

--- a/README.mkd
+++ b/README.mkd
@@ -271,6 +271,14 @@ If you have `grep` aliased to something which changes its output, for example `g
 let g:gitgutter_escape_grep = 1
 ```
 
+#### Use a custom `grep` command
+
+If you use an alternative to grep, you can tell vim-gitgutter to use it here.
+
+```viml
+let g:gitgutter_grep_command = ' | grep --color=never -e "^@@"'
+```
+
 #### To turn off vim-gitgutter by default
 
 Add `let g:gitgutter_enabled = 0` to your `~/.vimrc`.

--- a/README.mkd
+++ b/README.mkd
@@ -179,7 +179,6 @@ You can customise:
 * Line highlights
 * Extra arguments for `git diff`
 * Key mappings
-* Whether or not to escape `grep` (default to no)
 * Whether or not vim-gitgutter is on initially (defaults to on)
 * Whether or not signs are shown (defaults to yes)
 * Whether or not line highlighting is on initially (defaults to off)
@@ -262,14 +261,6 @@ let g:gitgutter_map_keys = 0
 
 See above for configuring maps for hunk-jumping and staging/reverting.
 
-
-#### Whether or not to escape `grep`
-
-If you have `grep` aliased to something which changes its output, for example `grep --color=auto -H`, you will need to tell vim-gitgutter to use raw grep:
-
-```viml
-let g:gitgutter_escape_grep = 1
-```
 
 #### Use a custom `grep` command
 

--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -4,12 +4,12 @@ if exists('g:gitgutter_grep_command')
 else
   let s:grep_available = executable('grep')
   if s:grep_available
-    let s:grep_command = ' | '.(g:gitgutter_escape_grep ? '\grep' : 'grep')
+    let s:grep_command = (g:gitgutter_escape_grep ? '\grep' : 'grep')
     let s:grep_help = gitgutter#utility#system('grep --help')
     if s:grep_help =~# '--color'
       let s:grep_command .= ' --color=never'
     endif
-    let s:grep_command .= ' -e '.gitgutter#utility#shellescape('^@@ ')
+    let s:grep_command .= ' -e'
   endif
 endif
 let s:hunk_re = '^@@ -\(\d\+\),\?\(\d*\) +\(\d\+\),\?\(\d*\) @@'
@@ -62,7 +62,7 @@ function! gitgutter#diff#run_diff(realtime, use_external_grep)
   endif
 
   if a:use_external_grep && s:grep_available
-    let cmd .= s:grep_command
+    let cmd .= ' | '.s:grep_command.' '.gitgutter#utility#shellescape('^@@ ')
   endif
 
   if (a:use_external_grep && s:grep_available) || a:realtime

--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -4,12 +4,7 @@ if exists('g:gitgutter_grep_command')
 else
   let s:grep_available = executable('grep')
   if s:grep_available
-    let s:grep_command = (g:gitgutter_escape_grep ? '\grep' : 'grep')
-    let s:grep_help = gitgutter#utility#system('grep --help')
-    if s:grep_help =~# '--color'
-      let s:grep_command .= ' --color=never'
-    endif
-    let s:grep_command .= ' -e'
+    let s:grep_command = 'grep --color=never -e'
   endif
 endif
 let s:hunk_re = '^@@ -\(\d\+\),\?\(\d*\) +\(\d\+\),\?\(\d*\) @@'

--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -1,11 +1,16 @@
-let s:grep_available = executable('grep')
-if s:grep_available
-  let s:grep_command = ' | '.(g:gitgutter_escape_grep ? '\grep' : 'grep')
-  let s:grep_help = gitgutter#utility#system('grep --help')
-  if s:grep_help =~# '--color'
-    let s:grep_command .= ' --color=never'
+if exists('g:gitgutter_grep_command')
+  let s:grep_available = 1
+  let s:grep_command = g:gitgutter_grep_command
+else
+  let s:grep_available = executable('grep')
+  if s:grep_available
+    let s:grep_command = ' | '.(g:gitgutter_escape_grep ? '\grep' : 'grep')
+    let s:grep_help = gitgutter#utility#system('grep --help')
+    if s:grep_help =~# '--color'
+      let s:grep_command .= ' --color=never'
+    endif
+    let s:grep_command .= ' -e '.gitgutter#utility#shellescape('^@@ ')
   endif
-  let s:grep_command .= ' -e '.gitgutter#utility#shellescape('^@@ ')
 endif
 let s:hunk_re = '^@@ -\(\d\+\),\?\(\d*\) +\(\d\+\),\?\(\d*\) @@'
 

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -119,6 +119,7 @@ You can customise:
 - Line highlights
 - Extra arguments for git-diff
 - Key mappings
+- The grep executable used
 - Whether or not to escape grep (defaults to no)
 - Whether or not vim-gitgutter is on initially (defaults to on)
 - Whether or not signs are shown (defaults to yes)
@@ -213,6 +214,11 @@ To change the hunk-staging/reverting/previewing maps (defaults shown):
 <
 
 TO ESCAPE GREP
+
+To use a custom invocation for grep, use this:
+>
+  let g:gitgutter_grep_command = ' | grep --color=never -e "^@@ "'
+<
 
 To avoid any alias you have for grep, use this:
 >

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -120,7 +120,6 @@ You can customise:
 - Extra arguments for git-diff
 - Key mappings
 - The grep executable used
-- Whether or not to escape grep (defaults to no)
 - Whether or not vim-gitgutter is on initially (defaults to on)
 - Whether or not signs are shown (defaults to yes)
 - Whether or not line highlighting is on initially (defaults to off)
@@ -213,16 +212,11 @@ To change the hunk-staging/reverting/previewing maps (defaults shown):
   nmap <Leader>hp <Plug>GitGutterPreviewHunk
 <
 
-TO ESCAPE GREP
+TO USE A CUSTOM GREP COMMAND
 
 To use a custom invocation for grep, use this:
 >
   let g:gitgutter_grep_command = 'grep --color=never -e'
-<
-
-To avoid any alias you have for grep, use this:
->
-  let g:gitgutter_escape_grep = 1
 <
 
 TO TURN OFF VIM-GITGUTTER BY DEFAULT

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -217,7 +217,7 @@ TO ESCAPE GREP
 
 To use a custom invocation for grep, use this:
 >
-  let g:gitgutter_grep_command = ' | grep --color=never -e "^@@ "'
+  let g:gitgutter_grep_command = 'grep --color=never -e'
 <
 
 To avoid any alias you have for grep, use this:

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -46,7 +46,6 @@ endtry
 
 call s:set('g:gitgutter_sign_modified_removed',    '~_')
 call s:set('g:gitgutter_diff_args',                  '')
-call s:set('g:gitgutter_escape_grep',                 0)
 call s:set('g:gitgutter_map_keys',                    1)
 call s:set('g:gitgutter_avoid_cmd_prompt_on_windows', 1)
 


### PR DESCRIPTION
This could potentially be a better method of fixing the issue that 5c23cadf57d2bd4b072e46f2320c9acec53134d6 fixed, as well as d59ac0394aa30753ab4c4350a9c43b3fda14bbb5, both of which added to the startup time of vim. It might even be worth it to pull out those options in favor of this one.

With this change, setting `g:gitgutter_grep_command` to `'grep --color=never -e'` in your vimrc **greatly reduces startup time**.

Before this change, `diff.vim` was a major bottleneck because it calls `grep --help`. This is mostly unnecessary except in a few cases where the user is running a nonstandard version of grep.

`vim --startuptime start.out large_file.sql` before:

    times in msec
     clock   self+sourced   self:  sourced script
     clock   elapsed:              other lines

    000.026  000.026: --- VIM STARTING ---
    [...]
    068.463  003.645  003.500: sourcing /home/dchurch/.vim/plugin/gitgutter.vim
    [...]
    150.957  000.208  000.208: sourcing /home/dchurch/.vim/autoload/gitgutter.vim
    151.294  000.196  000.196: sourcing /home/dchurch/.vim/autoload/gitgutter/utility.vim
    165.059  012.619  012.619: sourcing /home/dchurch/.vim/autoload/gitgutter/diff.vim
    236.901  000.188  000.188: sourcing /home/dchurch/.vim/autoload/gitgutter/hunk.vim
    237.289  000.233  000.233: sourcing /home/dchurch/.vim/autoload/gitgutter/sign.vim
    [...]
    337.673  000.004: --- VIM STARTED ---

After change, and setting `g:gitgutter_grep_command = 'grep --color=never -e'`:

    000.026  000.026: --- VIM STARTING ---
    [...]
    064.873  002.713  002.591: sourcing /home/dchurch/.vim/plugin/gitgutter.vim
    [...]
    134.109  000.149  000.149: sourcing /home/dchurch/.vim/autoload/gitgutter.vim
    134.337  000.147  000.147: sourcing /home/dchurch/.vim/autoload/gitgutter/utility.vim
    135.411  000.232  000.232: sourcing /home/dchurch/.vim/autoload/gitgutter/diff.vim
    187.831  000.180  000.180: sourcing /home/dchurch/.vim/autoload/gitgutter/hunk.vim
    188.223  000.175  000.175: sourcing /home/dchurch/.vim/autoload/gitgutter/sign.vim
    [...]
    285.008  000.004: --- VIM STARTED ---