### PR TITLE
check pumvisible before precess_buffer

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -169,7 +169,7 @@ augroup gitgutter
     autocmd BufEnter,BufWritePost,FileChangedShellPost *
           \  if gettabvar(tabpagenr(), 'gitgutter_didtabenter') |
           \   call settabvar(tabpagenr(), 'gitgutter_didtabenter', 0) |
-          \ else |
+          \ elseif !pumvisible()|
           \   call gitgutter#process_buffer(bufnr(''), 0) |
           \ endif
     autocmd TabEnter *


### PR DESCRIPTION
Complete with preview in neovim can't works with `gitgutter#process_buffer`.
This is a temporary workaround for issue #310 