### PR TITLE
Add a call to GitGutterProcessBufferHook, a user-defined hook

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -30,6 +30,9 @@ function! gitgutter#process_buffer(bufnr, realtime)
   else
     call gitgutter#hunk#reset()
   endif
+  if exists("*GitGutterProcessBufferHook")
+    call GitGutterProcessBufferHook(a:bufnr)
+  endif
 endfunction
 
 

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -27,10 +27,10 @@ function! gitgutter#process_buffer(bufnr, realtime)
     catch /diff failed/
       call gitgutter#hunk#reset()
     endtry
+    silent doautocmd User GitGutter
   else
     call gitgutter#hunk#reset()
   endif
-  silent doautocmd User GitGutter
 endfunction
 
 

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -30,7 +30,7 @@ function! gitgutter#process_buffer(bufnr, realtime)
   else
     call gitgutter#hunk#reset()
   endif
-  silent doautocmd User GitGutterProcessedBuffer
+  silent doautocmd User GitGutter
 endfunction
 
 

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -30,9 +30,7 @@ function! gitgutter#process_buffer(bufnr, realtime)
   else
     call gitgutter#hunk#reset()
   endif
-  if exists("*GitGutterProcessBufferHook")
-    call GitGutterProcessBufferHook(a:bufnr)
-  endif
+  silent doautocmd User GitGutterProcessedBuffer
 endfunction
 
 

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -286,15 +286,15 @@ Add to your |vimrc|
 <
 
 TO EXECUTE USER CODE AFTER VIM-GITGUTTER UPDATES ITS STATUS
-                                                     *GitGutterProcessedBuffer*
+                                                            *autocmd-GitGutter*
 
 After updating the status of a buffer, vim-gitgutter will fire a |User|
-|autocmd| with the event GitGutterProcessedBuffer. You can define an autocmd
-to run your code on this event.
+|autocmd| with the event GitGutter. You can define an autocmd to run your code
+on this event.
 
 Add to your |vimrc|
 >
-  autocmd User GitGutterProcessedBuffer call lightline#update()
+  autocmd User GitGutter call lightline#update()
 <
 
 ===============================================================================

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -282,7 +282,19 @@ instead:
 
 Add to your |vimrc|
 >
-let g:gitgutter_async = 0
+  let g:gitgutter_async = 0
+<
+
+TO EXECUTE USER CODE AFTER VIM-GITGUTTER UPDATES ITS STATUS
+                                                     *GitGutterProcessedBuffer*
+
+After updating the status of a buffer, vim-gitgutter will fire a |User|
+|autocmd| with the event GitGutterProcessedBuffer. You can define an autocmd
+to run your code on this event.
+
+Add to your |vimrc|
+>
+  autocmd User GitGutterProcessedBuffer call lightline#update()
 <
 
 ===============================================================================


### PR DESCRIPTION
This hook allows for easier integration with other user configuration,
including statuslines, etc.

One specific use case is integration with [lightline](https://github.com/itchyny/lightline.vim), when using information from GitGutterGetHunkSummary in a lightline ```component_expand``` segment.