### PR TITLE
Fix Neovim jobstart() invocation

### DIFF
--- a/autoload/gitgutter/async.vim
+++ b/autoload/gitgutter/async.vim
@@ -9,7 +9,8 @@ endfunction
 
 function! gitgutter#async#execute(cmd)
   if has('nvim')
-    let job_id = jobstart([&shell, &shellcmdflag, a:cmd], {
+    let command = split(&shell) + split(&shellcmdflag) + [a:cmd]
+    let job_id = jobstart(command, {
           \ 'on_stdout': function('gitgutter#async#handle_diff_job_nvim'),
           \ 'on_stderr': function('gitgutter#async#handle_diff_job_nvim'),
           \ 'on_exit':   function('gitgutter#async#handle_diff_job_nvim')


### PR DESCRIPTION
[Neovim's jobstart()](https://neovim.io/doc/user/eval.html#jobstart()) directly
executes the command when a list of arguments is passed. This commit makes sure
providing a space in &shell or &shellcmdflag is supported.

This needs to be explicitly supported, otherwise this generates an error (binary
not found):

```vimscript
set shell=bash\ -l
```