### PR TITLE
Support VIM older than 7.04

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -9,6 +9,13 @@ function! gitgutter#hunk#hunks() abort
 endfunction
 
 function! gitgutter#hunk#summary(bufnr) abort
+  if v:version < 704
+    let summary = getbufvar(a:bufnr, 'gitgutter_summary')
+    if empty(summary)
+      return [0,0,0]
+    endif
+    return summary
+  endif
   return getbufvar(a:bufnr, 'gitgutter_summary', [0,0,0])
 endfunction
 


### PR DESCRIPTION
The `getbufvar` call in 7.04 now takes a 3rd argument to optionally
return a default value. This maintains that ability, but puts in logic
to safely fix this on older vim installations.