### PR TITLE
Use /bin/sh as default shell to maintain OpenBSD compatibility

### DIFF
--- a/autoload/gitgutter/async.vim
+++ b/autoload/gitgutter/async.vim
@@ -18,7 +18,7 @@ function! gitgutter#async#execute(cmd) abort
 
   if has('nvim')
     if has('unix')
-      let command = ["/bin/bash", "-c", a:cmd]
+      let command = ["/bin/sh", "-c", a:cmd]
     elseif has('win32')
       let command = ["cmd.exe", "/c", a:cmd]
     else
@@ -49,7 +49,7 @@ function! gitgutter#async#execute(cmd) abort
     " only occurs when a file is not tracked by git).
 
     if has('unix')
-      let command = ["/bin/bash", "-c", a:cmd]
+      let command = ["/bin/sh", "-c", a:cmd]
     elseif has('win32')
       " Help docs recommend {command} be a string on Windows.  But I think
       " they also say that will run the command directly, which I believe would

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -186,7 +186,7 @@ function! gitgutter#utility#use_known_shell() abort
   if has('unix')
     let s:shell = &shell
     let s:shellcmdflag = &shellcmdflag
-    set shell=/bin/bash
+    set shell=/bin/sh
     set shellcmdflag=-c
   endif
 endfunction


### PR DESCRIPTION
Changed "/bin/bash" calls to "/bin/sh" as bash is not part of OpenBSD base system.  Tested both gutter and async operations.