### PR TITLE
Define g:gitgutter_shell_command

### DIFF
--- a/autoload/gitgutter/async.vim
+++ b/autoload/gitgutter/async.vim
@@ -17,7 +17,9 @@ function! gitgutter#async#execute(cmd) abort
   let bufnr = gitgutter#utility#bufnr()
 
   if has('nvim')
-    if has('unix')
+    if exists('g:gitgutter_shell_command')
+      let command = [g:gitgutter_shell_command, "-c", a:cmd]
+    elseif has('unix')
       let command = ["/bin/bash", "-c", a:cmd]
     elseif has('win32')
       let command = ["cmd.exe", "/c", a:cmd]
@@ -48,7 +50,9 @@ function! gitgutter#async#execute(cmd) abort
     " ignored (and thus signs are not updated; this assumes that an error
     " only occurs when a file is not tracked by git).
 
-    if has('unix')
+    if exists('g:gitgutter_shell_command')
+      let command = [g:gitgutter_shell_command, "-c", a:cmd]
+    elseif has('unix')
       let command = ["/bin/bash", "-c", a:cmd]
     elseif has('win32')
       " Help docs recommend {command} be a string on Windows.  But I think

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -186,7 +186,11 @@ function! gitgutter#utility#use_known_shell() abort
   if has('unix')
     let s:shell = &shell
     let s:shellcmdflag = &shellcmdflag
-    set shell=/bin/bash
+    if exists('g:gitgutter_shell_command')
+      let &shell = g:gitgutter_shell_command
+    else
+      set shell=/bin/bash
+    endif
     set shellcmdflag=-c
   endif
 endfunction


### PR DESCRIPTION
So that other default shells than `/bin/bash` can be used, especially on systems that do not have `/bin/bash`.