### PR TITLE
Improve documentation

### DIFF
--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -138,6 +138,7 @@ Commands for staging or undoing individual hunks:
 
   :GitGutterPreviewHunk                                 *:GitGutterPreviewHunk*
       Preview the hunk the cursor is in.
+      Use |:pclose| or |CTRL-W CTRL-Z| to close the preview window.
 
 ===============================================================================
 5. AUTOCOMMAND                                               *GitGutterAutocmd*


### PR DESCRIPTION
Add `:pclose` and `CTRL-W CTRL-Z` commands to `:GitGutterPreviewHunk` description.