### PR TITLE
Declare nvim's callback as a dict function

### DIFF
--- a/autoload/gitgutter/async.vim
+++ b/autoload/gitgutter/async.vim
@@ -79,7 +79,7 @@ function! gitgutter#async#execute(cmd) abort
 endfunction
 
 
-function! gitgutter#async#handle_diff_job_nvim(job_id, data, event) abort
+function! gitgutter#async#handle_diff_job_nvim(job_id, data, event) dict abort
   call gitgutter#debug#log('job_id: '.a:job_id.', event: '.a:event.', buffer: '.self.buffer)
 
   let job_bufnr = self.buffer


### PR DESCRIPTION
neovim/neovim#5529 merged support for Vim's partial functions, which
made nvim more strict about dictionary functions.  This means the
implicit self variable isn't available unless a function is annoted as a
dict function or defined as part of a dictionary.

Closes #392