### PR TITLE
Detect git client version >= 1.7.2 without using a regular expression

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -177,7 +177,7 @@ endfunction
 " True for git v1.7.2+.
 function! gitgutter#utility#git_supports_command_line_config_override() abort
   call system(g:gitgutter_git_executable.' -c foo.bar=baz --version')
-  return v:shell_error == 0
+  return !v:shell_error
 endfunction
 
 function! gitgutter#utility#stringify(list) abort

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -176,7 +176,7 @@ endfunction
 
 " True for git v1.7.2+.
 function! gitgutter#utility#git_supports_command_line_config_override() abort
-  system(g:gitgutter_git_executable.' -c foo.bar=baz --version')
+  call system(g:gitgutter_git_executable.' -c foo.bar=baz --version')
   return v:shell_error == 0
 endfunction
 

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -174,14 +174,10 @@ function! gitgutter#utility#strip_trailing_new_line(line) abort
   return substitute(a:line, '\n$', '', '')
 endfunction
 
-function! gitgutter#utility#git_version() abort
-  return matchstr(system(g:gitgutter_git_executable.' --version'), '[0-9.]\+')
-endfunction
-
 " True for git v1.7.2+.
 function! gitgutter#utility#git_supports_command_line_config_override() abort
-  let [major, minor, patch; _] = split(gitgutter#utility#git_version(), '\.')
-  return major > 1 || (major == 1 && minor > 7) || (minor == 7 && patch > 1)
+  system(g:gitgutter_git_executable.' -c foo.bar=baz --version')
+  return v:shell_error == 0
 endfunction
 
 function! gitgutter#utility#stringify(list) abort


### PR DESCRIPTION
We use a custom version of git at work and our modified version string breaks git_gutter's detection of a git 1.7.2+ client. By borrowing from https://github.com/git/git/blob/35f6318d44379452d8d33e880d8df0267b4a0cd0/contrib/hooks/multimail/git_multimail.py#L416-L432 it's possible to determine if we support overriding config on the command line without relying on a regex. This should be more reliable and remove some unnecessary code.

My vimscript proficiency is quite poor, so any suggestions on writing this in a more idiomatic manner would be appreciated. :bow: