### PR TITLE
Don't write file when it's impossible to do so.

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -85,7 +85,9 @@ function! gitgutter#diff#run_diff(realtime, preserve_full_diff) abort
     let op_mark_start = getpos("'[")
     let op_mark_end   = getpos("']")
 
-    execute 'keepalt noautocmd silent write!' buff_file
+    if &write
+        execute 'keepalt noautocmd silent write!' buff_file
+    endif
 
     call setbufvar(bufnr, "&mod", modified)
     call setpos("'[", op_mark_start)


### PR DESCRIPTION
I wrote a bash script that uses vim to open a text file. It uses the `-m` switch, which prevents vim from being able to write files. It also causes gitgutter to throw errors, specifically on this [line](https://github.com/airblade/vim-gitgutter/blob/master/autoload/gitgutter/diff.vim#L88).

I simply added an `if` statement around it to prevent vim from trying to write if the settings disallow it.
