### PR TITLE
Improve support for altering base of diffs

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -256,4 +256,16 @@ function! gitgutter#preview_hunk() abort
   call gitgutter#utility#restore_shell()
 endfunction
 
+function! gitgutter#set_diff_base(base)
+  let b:gitgutter_diff_base = a:base
+endfunction
+
+function! gitgutter#get_diff_base()
+  if exists('b:gitgutter_diff_base')
+    return b:gitgutter_diff_base
+  else
+    return g:gitgutter_diff_base
+  endif
+endfunction
+
 " }}}

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -256,8 +256,13 @@ function! gitgutter#preview_hunk() abort
   call gitgutter#utility#restore_shell()
 endfunction
 
-function! gitgutter#set_diff_base(base)
-  let b:gitgutter_diff_base = a:base
+function! gitgutter#set_diff_base(...)
+  if a:0 == 0
+    let b:gitgutter_diff_base = ''
+  else
+    let b:gitgutter_diff_base = a:1
+  endif
+  call gitgutter#process_buffer(bufnr(''), 0)
 endfunction
 
 function! gitgutter#get_diff_base()

--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -71,7 +71,7 @@ function! gitgutter#diff#run_diff(realtime, preserve_full_diff) abort
   endif
 
   if a:realtime
-    let blob_name = g:gitgutter_diff_base.':'.gitgutter#utility#shellescape(gitgutter#utility#file_relative_to_repo_root())
+    let blob_name = gitgutter#get_diff_base().':'.gitgutter#utility#shellescape(gitgutter#utility#file_relative_to_repo_root())
     let blob_file = s:temp_index
     let buff_file = s:temp_buffer
     let extension = gitgutter#utility#extension()
@@ -105,7 +105,7 @@ function! gitgutter#diff#run_diff(realtime, preserve_full_diff) abort
   if a:realtime
     let cmd .= ' -- '.blob_file.' '.buff_file
   else
-    let cmd .= g:gitgutter_diff_base.' -- '.gitgutter#utility#shellescape(gitgutter#utility#filename())
+    let cmd .= gitgutter#get_diff_base().' -- '.gitgutter#utility#shellescape(gitgutter#utility#filename())
   endif
 
   if !a:preserve_full_diff && s:grep_available

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -140,6 +140,14 @@ Commands for staging or undoing individual hunks:
       Preview the hunk the cursor is in.
       Use |:pclose| or |CTRL-W_CTRL-Z| to close the preview window.
 
+Commands for altering the comparison
+
+  :GitGutterBase                                               *:GitGutterBase*
+    Alter the base used to determine which lines have changed.
+    Takes an optional single argument specifying the commit against which
+    comparisons are done. If no argument is supplied, comparisons will be
+    against the index.
+
 ===============================================================================
 5. AUTOCOMMAND                                               *GitGutterAutocmd*
 
@@ -229,11 +237,14 @@ colorscheme or |vimrc|:
 
 THE BASE OF THE DIFF
 
-By default buffers are diffed against the index.  To diff against a commit
-instead:
+By default buffers are diffed against the index.  To default to diff against a
+commit instead:
 >
   let g:gitgutter_diff_base = '<commit SHA>'
 <
+
+The GitGutterBase command can be used to diff against a different commit for
+individual buffers.
 
 EXTRA ARGUMENTS FOR GIT-DIFF
 

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -71,6 +71,7 @@ command -bar GitGutter    call gitgutter#process_buffer(bufnr(''), 0)
 command -bar GitGutterDisable call gitgutter#disable()
 command -bar GitGutterEnable  call gitgutter#enable()
 command -bar GitGutterToggle  call gitgutter#toggle()
+command -bar -nargs=? GitGutterBase    call gitgutter#set_diff_base(<f-args>)
 
 " }}}
 


### PR DESCRIPTION
Allow per-buffer configuration of base used for diffs and add `GitGutterBase` command to set the base and update the display.

I open up files from pull requests within vim to more closely examine the changes, and in those cases I want to use the PR target as the base for diffs to help with jumping between hunks. But, when I'm writing code the default of diffing against the index (or possibly HEAD) is more useful. Having a single setting for the base across the entire vim session can make this more difficult, also having a command to change the setting makes it easier to use tab completion.