### PR TITLE
Improve hunk preview generation

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -239,16 +239,18 @@ function! gitgutter#preview_hunk() abort
       call gitgutter#utility#warn('cursor is not in a hunk')
     else
       let diff_for_hunk = gitgutter#diff#generate_diff_for_hunk(diff, 'preview')
+      let lines_for_hunk = split(diff_for_hunk, "\n")
 
       silent! wincmd P
       if !&previewwindow
-        noautocmd execute 'bo' &previewheight 'new'
+        noautocmd execute 'botright' min([len(lines_for_hunk), &previewheight]) 'new'
         set previewwindow
       endif
 
-      setlocal noro modifiable filetype=diff buftype=nofile bufhidden=delete noswapfile
+      setlocal noreadonly modifiable filetype=diff buftype=nofile bufhidden=delete noswapfile
       execute "%delete_"
-      call append(0, split(diff_for_hunk, "\n"))
+      call setline(1, lines_for_hunk)
+      setlocal readonly nomodifiable
 
       noautocmd wincmd p
     endif

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -241,11 +241,17 @@ function! gitgutter#preview_hunk() abort
       let diff_for_hunk = gitgutter#diff#generate_diff_for_hunk(diff, 'preview')
       let lines_for_hunk = split(diff_for_hunk, "\n")
       let number_lines_for_hunk = len(lines_for_hunk)
+      let window_heigth = min([number_lines_for_hunk, &previewheight])
 
       silent! wincmd P
       if !&previewwindow
-        noautocmd execute 'botright' min([number_lines_for_hunk, &previewheight]) 'new'
+        " Open the preview window
+        noautocmd execute 'botright' window_heigth 'new'
         set previewwindow
+      else
+        " The current window is the preview window
+        " Resize it to the correct size
+        execute 'resize' window_heigth
       endif
 
       setlocal noreadonly modifiable filetype=diff buftype=nofile bufhidden=delete noswapfile

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -240,10 +240,11 @@ function! gitgutter#preview_hunk() abort
     else
       let diff_for_hunk = gitgutter#diff#generate_diff_for_hunk(diff, 'preview')
       let lines_for_hunk = split(diff_for_hunk, "\n")
+      let number_lines_for_hunk = len(lines_for_hunk)
 
       silent! wincmd P
       if !&previewwindow
-        noautocmd execute 'botright' min([len(lines_for_hunk), &previewheight]) 'new'
+        noautocmd execute 'botright' min([number_lines_for_hunk, &previewheight]) 'new'
         set previewwindow
       endif
 
@@ -251,6 +252,14 @@ function! gitgutter#preview_hunk() abort
       execute "%delete_"
       call setline(1, lines_for_hunk)
       setlocal readonly nomodifiable
+
+      if g:gitgutter_change_statusline == 1
+        let status = printf('GitGutter: %d lines', number_lines_for_hunk)
+        if number_lines_for_hunk > &previewheight
+          let status .= ' | Scroll for more'
+        endif
+        let &l:statusline = status
+      endif
 
       noautocmd wincmd p
     endif

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -325,14 +325,13 @@ Add to your |vimrc|
 let g:gitgutter_async = 0
 <
 
-TO STOP VIM-GITGUTTER FROM TOUCHING YOUR STATUSLINE
+TO USE A CUSTOM STATUSLINE
 
-By default, the statusline on preview windows opened by vim-gitgutter is changed to indicate if the diff fits in the preview window (with a maximum |previewheight|.
-To leave the statusline alone:
+To change the statusline on preview windows to indicate if the diff fits in the preview window (with a maximum |previewheight|).
 
 Add to your |vimrc|
 >
-let g:gitgutter_change_statusline = 0
+let g:gitgutter_change_statusline = 1
 <
 
 ===============================================================================

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -325,6 +325,16 @@ Add to your |vimrc|
 let g:gitgutter_async = 0
 <
 
+TO STOP VIM-GITGUTTER FROM TOUCHING YOUR STATUSLINE
+
+By default, the statusline on preview windows opened by vim-gitgutter is changed to indicate if the diff fits in the preview window (with a maximum |previewheight|.
+To leave the statusline alone:
+
+Add to your |vimrc|
+>
+let g:gitgutter_change_statusline = 0
+<
+
 ===============================================================================
 7. FAQ                                                           *GitGutterFAQ*
 

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -57,7 +57,7 @@ call s:set('g:gitgutter_avoid_cmd_prompt_on_windows', 1)
 call s:set('g:gitgutter_async',                       1)
 call s:set('g:gitgutter_log',                         0)
 call s:set('g:gitgutter_git_executable',          'git')
-call s:set('g:gitgutter_change_statusline',           1)
+call s:set('g:gitgutter_change_statusline',           0)
 
 if !executable(g:gitgutter_git_executable)
   call gitgutter#utility#warn('cannot find git. Please set g:gitgutter_git_executable.')

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -57,6 +57,7 @@ call s:set('g:gitgutter_avoid_cmd_prompt_on_windows', 1)
 call s:set('g:gitgutter_async',                       1)
 call s:set('g:gitgutter_log',                         0)
 call s:set('g:gitgutter_git_executable',          'git')
+call s:set('g:gitgutter_change_statusline',           1)
 
 if !executable(g:gitgutter_git_executable)
   call gitgutter#utility#warn('cannot find git. Please set g:gitgutter_git_executable.')


### PR DESCRIPTION
- Don't generate preview windows with empty lines. Treat
`&previewheight` as a maximum value, open smaller windows for smaller
diffs. This also eliminates the extra empty line that the preview
created.
- Keep the preview buffer unmodified after inserting the diff.

This is an improvement over https://github.com/somini/vim-gitgutter/commit/e648217c28a63ddf8b08546942a0462d6bf6d395