### PR TITLE
Fix corrupted characters in latin1 terminals

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -42,11 +42,11 @@ call s:set('g:gitgutter_override_sign_column_highlight', 1)
 call s:set('g:gitgutter_sign_added',                '+')
 call s:set('g:gitgutter_sign_modified',             '~')
 call s:set('g:gitgutter_sign_removed',              '_')
-try
+if has("gui_running") || &encoding == "utf-8"
   call s:set('g:gitgutter_sign_removed_first_line', '‾')
-catch /E239/
-  let g:gitgutter_sign_removed_first_line = '_^'
-endtry
+else
+  call s:set('g:gitgutter_sign_removed_first_line', '_^')
+endif
 
 call s:set('g:gitgutter_sign_modified_removed',    '~_')
 call s:set('g:gitgutter_diff_args',                  '')


### PR DESCRIPTION
This fix at least makes it so if [vim-airline](https://github.com/bling/vim-airline) and [cream-showinvisibles](https://github.com/albfan/cream-showinvisibles) don't show unicode characters, neither will vim-gitgutter.

Based on the settings of `&encoding` and `has('gui_running')` we should decide whether to show UTF-8 characters. These settings get set [and sometimes reset after your vimrc loads] automagically based on:

* how Vim interprets what you set your TERM environment variable to
* whether the value of LC_MESSAGES =~ /\.utf8/
* whether the value of LC_CTYPE =~ /\.utf8/
* evil spirits summoned through the value of TERMCAP

I don't understand it fully, but I tested it in 3 environments and this fix works in all 3 of them.