### PR TITLE
Trigger update when the buffer is written

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -218,6 +218,7 @@ augroup gitgutter
         \   call gitgutter#process_buffer(bufnr(''), 0) |
         \ endif
 
+  autocmd BufWritePost                      * call gitgutter#process_buffer(bufnr(''), 0)
   autocmd CursorHold,CursorHoldI            * call gitgutter#process_buffer(bufnr(''), 0)
   autocmd FileChangedShellPost,ShellCmdPost * call gitgutter#process_buffer(bufnr(''), 1)
 


### PR DESCRIPTION
It appears that 5bfe5b92099e0d332a7ca26c0263fab509ee9617 removed the BufWritePost autocmd that triggers processing when the buffer is written. The commit did not mention any reason for its removal (maybe I am missing something?). However it is useful to have this behavior such that it is not required to set updatetime to a lower value only to trigger CursorHold autocmds when it can instead be triggered earlier when the user explicitly updates the file.