### PR TITLE
Fixed call to current_hunk in hunk text object

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -108,8 +108,7 @@ function! gitgutter#hunk#cursor_in_hunk(hunk) abort
 endfunction
 
 function! gitgutter#hunk#text_object(inner) abort
-  let bufnr = bufnr('')
-  let hunk = s:current_hunk(bufnr)
+  let hunk = s:current_hunk()
 
   if empty(hunk)
     return


### PR DESCRIPTION
It appears that the ``s:current_hunk`` has been changed to take no argument, but the ``gitgutter#hunk#text_object`` still calls it with the result of ``bufnr('')``. This breaks some useful combos like ``vic``, which selects the entire hunk.

This commit fixes the call, restoring the intended behaviour of the hunk text object.