### PR TITLE
Improve GitGutter User autocommand: context/unsilent

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -140,7 +140,11 @@ function! gitgutter#diff#handler(bufnr, diff) abort
   endif
 
   call s:save_last_seen_change(a:bufnr)
-  execute "silent doautocmd" s:nomodeline "User GitGutter"
+  if exists('#User#GitGutter')
+    let g:gitgutter_hook_context = {'bufnr': a:bufnr}
+    execute 'doautocmd' s:nomodeline 'User GitGutter'
+    unlet g:gitgutter_hook_context
+  endif
 endfunction
 
 

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -159,6 +159,8 @@ event GitGutter.  You can listen for this event, for example:
 >
   autocmd User GitGutter call updateMyStatusLine()
 <
+A dictionary `g:gitgutter_hook_context` is made available during its execution,
+which contains an entry `bufnr` that contains the buffer number being updated.
 
 
 ===============================================================================


### PR DESCRIPTION
This provides `g:gitgutter_hook_context` during the hook's execution and
removes the `:silent`, but uses `exists()` instead.

The bufnr might be necessary to know in the User autocommand, e.g. to
clear some cache.
Not using`:silent` is good practice in general to not hide (wanted)
output and errors etc.