### PR TITLE
Conditionally define s:vimdiff

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -192,23 +192,25 @@ endfunction
 
 " Returns 1 if any of the given buffer's windows has the `&diff` option set,
 " or 0 otherwise.
-function! s:vimdiff(bufnr)
-  if exists('*win_findbuf')
+if exists('*win_findbuf')
+  function! s:vimdiff(bufnr) abort
     for winid in win_findbuf(a:bufnr)
       if getwinvar(winid, '&diff')
         return 1
       endif
     endfor
     return 0
-  else
+  endfunction
+else
+  function! s:vimdiff(bufnr) abort
     for winnr in range(1, winnr('$'))
       if winbufnr(winnr) == a:bufnr && getwinvar(winnr, '&diff')
         return 1
       endif
     endfor
     return 0
-  endif
-endfunction
+  endfunction
+endif
 
 function! s:windows()
   return has('win64') || has('win32') || has('win32unix') || has('win16')


### PR DESCRIPTION
This optimizes it a bit since the `exists()` is not called always.