### PR TITLE
Skip duplicates from tabpagebuflist

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -3,7 +3,12 @@ let s:t_string = type('')
 " Primary functions {{{
 
 function! gitgutter#all(force) abort
-  for bufnr in uniq(sort(tabpagebuflist()))
+  let processed = {}
+  for bufnr in tabpagebuflist()
+    if has_key(processed, bufnr)
+      continue
+    endif
+    let processed[bufnr] = 1
     let file = expand('#'.bufnr.':p')
     if !empty(file)
       call gitgutter#init_buffer(bufnr)
@@ -57,9 +62,13 @@ function! gitgutter#disable() abort
   for i in range(tabpagenr('$'))
     call extend(buflist, tabpagebuflist(i + 1))
   endfor
-  call uniq(sort(buflist))
 
+  let processed = {}
   for bufnr in buflist
+    if has_key(processed, bufnr)
+      continue
+    endif
+    let processed[bufnr] = 1
     let file = expand('#'.bufnr.':p')
     if !empty(file)
       call s:clear(bufnr)

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -3,7 +3,7 @@ let s:t_string = type('')
 " Primary functions {{{
 
 function! gitgutter#all(force) abort
-  for bufnr in tabpagebuflist()
+  for bufnr in uniq(sort(tabpagebuflist()))
     let file = expand('#'.bufnr.':p')
     if !empty(file)
       call gitgutter#init_buffer(bufnr)
@@ -57,6 +57,7 @@ function! gitgutter#disable() abort
   for i in range(tabpagenr('$'))
     call extend(buflist, tabpagebuflist(i + 1))
   endfor
+  call uniq(sort(buflist))
 
   for bufnr in buflist
     let file = expand('#'.bufnr.':p')


### PR DESCRIPTION
There are two approaches in here - `uniq()` is not available in some older Vims.
I recommend to squash it (i.e. use the later approach).