### PR TITLE
s:fix_file_references: handle diff.mnemonicPrefix

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -229,7 +229,7 @@ endfunction
 function! s:fix_file_references(bufnr, hunk_diff)
   let filepath = gitgutter#utility#repo_path(a:bufnr, 0)
   let diff = a:hunk_diff
-  for tmp in matchlist(diff, '\vdiff --git a/(\S+) b/(\S+)\n')[1:2]
+  for tmp in matchlist(diff, '\vdiff --git ./(\S+) ./(\S+)\n')[1:2]
     let diff = substitute(diff, tmp, filepath, 'g')
   endfor
   return diff


### PR DESCRIPTION
An alternative would be to run `git` with no user config always, i.e.
setting `GIT_CONFIG_NOSYSTEM` and `HOME=/dev/null` (different for
Windows then) in its environment.  Maybe there's an easier way / single
option for this..