### PR TITLE
Fix gitgutter#utility#warn_once: use echom

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -150,8 +150,11 @@ function! gitgutter#diff#handler(bufnr, diff) abort
   call gitgutter#hunk#set_hunks(a:bufnr, gitgutter#diff#parse_diff(a:diff))
   let modified_lines = gitgutter#diff#process_hunks(a:bufnr, gitgutter#hunk#hunks(a:bufnr))
 
-  if len(modified_lines) > g:gitgutter_max_signs
-    call gitgutter#utility#warn_once(a:bufnr, 'exceeded maximum number of signs (configured by g:gitgutter_max_signs).', 'max_signs')
+  let signs_count = len(modified_lines)
+  if signs_count > g:gitgutter_max_signs
+    call gitgutter#utility#warn_once(a:bufnr, printf(
+          \ 'exceeded maximum number of signs (%d > %d, configured by g:gitgutter_max_signs).',
+          \ signs_count, g:gitgutter_max_signs), 'max_signs')
     call gitgutter#sign#clear_signs(a:bufnr)
 
   else

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -37,7 +37,7 @@ function! gitgutter#utility#warn_once(bufnr, message, key) abort
   if empty(gitgutter#utility#getbufvar(a:bufnr, a:key))
     call gitgutter#utility#setbufvar(a:bufnr, a:key, '1')
     echohl WarningMsg
-    redraw | echo 'vim-gitgutter: ' . a:message
+    redraw | echom 'vim-gitgutter: ' . a:message
     echohl None
     let v:warningmsg = a:message
   endif


### PR DESCRIPTION
This a) logs the message to be seen in `:mess` and b) avoids the
hit-ENTER prompt (which is likely caused by the message not being
logged and Vim deciding that you need to see it then).

So a) fixes b).