### PR TITLE
Ignore the arguments when testing the grep executable

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -60,7 +60,7 @@ endif
 let default_grep = 'grep'
 call s:set('g:gitgutter_grep', default_grep)
 if !empty(g:gitgutter_grep)
-  if executable(g:gitgutter_grep)
+  if executable(split(g:gitgutter_grep)[0])
     if $GREP_OPTIONS =~# '--color=always'
       let g:gitgutter_grep .= ' --color=never'
     endif


### PR DESCRIPTION
Without this the '--color=never' [example](https://github.com/airblade/vim-gitgutter/blob/master/doc/gitgutter.txt#L299) wouldn't work.