### PR TITLE
Handle files in different drive on Windows

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -149,7 +149,7 @@ function! s:set_path(bufnr, path)
 endfunction
 
 function! gitgutter#utility#cd_cmd(bufnr, cmd) abort
-  let cd = s:unc_path(a:bufnr) ? 'pushd' : 'cd'
+  let cd = s:unc_path(a:bufnr) ? 'pushd' : (s:windows() ? 'cd /d' : 'cd')
   return cd.' '.s:dir(a:bufnr).' && '.a:cmd
 endfunction
 


### PR DESCRIPTION
On Windows, when gVim is opened with `pwd` of `C:/Users/USERNAME`, vim-gitgutter's `gitgutter#utility#set_repo_path` won't set the proper path for files in different drive, for example, `D:/src/dotfiles/vimrc`.

https://github.com/airblade/vim-gitgutter/blob/983193456f17a35fc6ccc2fde26b0936e0b348e3/autoload/gitgutter/utility.vim#L118

Above line assigns `'cd "D:/src/dotfiles" && git ls-files --error-unmatch --full-name vimrc'` to `cmd` when gVim opens `D:/src/dotfiles/vimrc`.

But since the `pwd` is under `C:`, running `cd` to directories under other drives does nothing and `git` command exits with an error. So we add [`/d` option](https://ss64.com/nt/cd.html) to allow `cd`ing to other drives.