### PR TITLE
Fix wrong signs when &encoding and &fileencoding differ

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -334,6 +334,9 @@ function! s:write_buffer(bufnr, file)
   if getbufvar(a:bufnr, '&fileformat') ==# 'dos'
     call map(bufcontents, 'v:val."\r"')
   endif
+  if getbufvar(a:bufnr, '&fileencoding') !=# &encoding
+    call map(bufcontents, 'iconv(v:val, &encoding, getbufvar(a:bufnr, "&fileencoding"))')
+  endif
   call writefile(bufcontents, a:file)
 endfunction
 


### PR DESCRIPTION
If file's encoding is different from Vim's &encoding, all lines which includes non-ascii characters show `~` sign.
I fixed it by converting before write the buffer.

I'm not sure if this is a good solution. JFYI.