### PR TITLE
diff: fix handling of empty file

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -332,6 +332,15 @@ endfunction
 function! s:write_buffer(bufnr, file)
   let bufcontents = getbufline(a:bufnr, 1, '$')
 
+  " Special case: empty buffer; do not write an empty line in this case.
+  if len(bufcontents) > 1 || bufcontents != ['']
+    if getbufvar(a:bufnr, '&endofline')
+          \ || (!getbufvar(a:bufnr, '&binary')
+          \     && (!exists('+fixendofline') || getbufvar(a:bufnr, '&fixendofline')))
+      call add(bufcontents, '')
+    endif
+  endif
+
   if getbufvar(a:bufnr, '&fileformat') ==# 'dos'
     call map(bufcontents, 'v:val."\r"')
   endif
@@ -345,7 +354,7 @@ function! s:write_buffer(bufnr, file)
     let bufcontents[0]='﻿'.bufcontents[0]
   endif
 
-  call writefile(bufcontents, a:file)
+  call writefile(bufcontents, a:file, 'b')
 endfunction
 
 


### PR DESCRIPTION
An empty, unchanged file was considered to be changed (a new line
added).
This patch fixes s:write_buffer to use binary mode with `writefile` to
not append a newline always, and does so manually for non-empty buffers,
according to &endofline, &binary and &fixendofline.

This is taken out of Neomake, and tested there in
https://github.com/neomake/neomake/blob/091d148b/tests/utils.vader#L713-L759.