### PR TITLE
gitgutter#utility#setbufvar: ensure bufnr is a number with setbufvar

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -11,7 +11,7 @@ function! gitgutter#utility#setbufvar(buffer, varname, val)
   let needs_setting = empty(dict)
   let dict[a:varname] = a:val
   if needs_setting
-    call setbufvar(a:buffer, 'gitgutter', dict)
+    call setbufvar(+a:buffer, 'gitgutter', dict)
   endif
 endfunction
 


### PR DESCRIPTION
Otherwise you might get "E93: More than one match for X" if there is a
buffer with "X" in its name besides buffer number X.