### PR TITLE
BufEnter: do not call process_buffer if not enabled

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -20,7 +20,9 @@ function! gitgutter#init_buffer(bufnr)
     if type(p) != s:t_string || empty(p)
       call gitgutter#utility#set_repo_path(a:bufnr)
     endif
+    return 1
   endif
+  return 0
 endfunction
 
 

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -220,8 +220,9 @@ augroup gitgutter
         \   let t:gitgutter_didtabenter = 0 |
         \   call gitgutter#all(!g:gitgutter_terminal_reports_focus) |
         \ else |
-        \   call gitgutter#init_buffer(bufnr('')) |
-        \   call gitgutter#process_buffer(bufnr(''), !g:gitgutter_terminal_reports_focus) |
+        \   if gitgutter#init_buffer(bufnr('')) |
+        \     call gitgutter#process_buffer(bufnr(''), !g:gitgutter_terminal_reports_focus) |
+        \   endif |
         \ endif
 
   autocmd CursorHold,CursorHoldI            * call gitgutter#process_buffer(bufnr(''), 0)


### PR DESCRIPTION
Make `gitgutter#init_buffer` return 0/1 and use it in the BufEnter
script.