### PR TITLE
[RFC] gitgutter#utility#is_active: check for b:gitgutter.disabled

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -46,7 +46,7 @@ endfunction
 " Returns truthy when the buffer's file should be processed; and falsey when it shouldn't.
 " This function does not and should not make any system calls.
 function! gitgutter#utility#is_active(bufnr) abort
-  return g:gitgutter_enabled &&
+  return !gitgutter#utility#getbufvar(a:bufnr, 'disabled', !g:gitgutter_enabled) &&
         \ !pumvisible() &&
         \ s:is_file_buffer(a:bufnr) &&
         \ s:exists_file(a:bufnr) &&


### PR DESCRIPTION
This allows to disable it for specific buffers:

    augroup vimrc_disable_gitgutter
      au!
      au BufReadPost /path/to/file call gitgutter#utility#setbufvar(expand('<abuf>'), 'disabled', 1)
    augroup END

It might be easier to use `b:gitgutter_enabled` (defaulting to 1, and
only read by gitgutter), but I've assumed that a single dict should be
used for (buffer)  settings?!

TODO:
 - [ ] doc