### PR TITLE
Fix gitgutter#utility#setbufvar for nonexistent buffers

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -7,11 +7,12 @@ function! gitgutter#utility#supports_overscore_sign()
 endfunction
 
 function! gitgutter#utility#setbufvar(buffer, varname, val)
-  let dict = get(getbufvar(a:buffer, ''), 'gitgutter', {})
+  let buffer = +a:buffer
+  let dict = get(getbufvar(buffer, '', {}), 'gitgutter', {})
   let needs_setting = empty(dict)
   let dict[a:varname] = a:val
   if needs_setting
-    call setbufvar(+a:buffer, 'gitgutter', dict)
+    call setbufvar(buffer, 'gitgutter', dict)
   endif
 endfunction
 


### PR DESCRIPTION
Use a default with `getbufvar` to not get an empty string.

Fixes:

> Error detected while processing function <SNR>163_on_stderr_nvim[1]..<lambda>10[1]..gitgutter#utility#setbufvar:
> line    1:
> E712: Argument of get() must be a List or Dictionary

I can trigger it using https://github.com/AndrewRadev/linediff.vim when
closing the windows / the tab.
Likely triggered with/through Neomake.