### PR TITLE
Trigger refresh on VimResume event

### DIFF
--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -203,6 +203,10 @@ augroup gitgutter
 
   autocmd FocusGained,ShellCmdPost * call gitgutter#all(1)
 
+  if exists('##VimResume')
+    autocmd VimResume * call gitgutter#all(1)
+  endif
+
   autocmd ColorScheme * call gitgutter#highlight#define_sign_column_highlight() | call gitgutter#highlight#define_highlights()
 
   " Disable during :vimgrep


### PR DESCRIPTION
VimResume is neovim event that is triggered when process is resumed to
foreground.

Fixes #550 

I tested this by install `ipwnponies/vim-gitgutter` via VimPlug (after uninstalling and cleaning up workaround).
```
:autocmd VimResume
--- Auto-Commands ---
gitgutter  VimResume
    *         call gitgutter#all(1)
```
To test original issue:
1. I modified a file and the gitgutter column showed unstaged changes.
1. Ctrl-z to background nvim.
1. `git add -A`
2. Resume process and gitgutter column no longer showed unstaged changes.