### PR TITLE
Add g:gitgutter_sign_allow_clobber to control clobbering

### DIFF
--- a/autoload/gitgutter/sign.vim
+++ b/autoload/gitgutter/sign.vim
@@ -181,7 +181,7 @@ function! s:upsert_new_gitgutter_signs(bufnr, modified_lines) abort
 
   for line in modified_lines
     let line_number = line[0]  " <number>
-    if index(other_signs, line_number) == -1  " don't clobber others' signs
+    if g:gitgutter_sign_allow_clobber || index(other_signs, line_number) == -1
       let name = s:highlight_name_for_change(line[1])
       if !has_key(old_gitgutter_signs, line_number)  " insert
         let id = s:next_sign_id()

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -245,6 +245,7 @@ Signs:~
     |g:gitgutter_signs|
     |g:gitgutter_highlight_lines|
     |g:gitgutter_max_signs|
+    |g:gitgutter_sign_allow_clobber|
     |g:gitgutter_sign_added|
     |g:gitgutter_sign_modified|
     |g:gitgutter_sign_removed|
@@ -331,6 +332,12 @@ Sets the maximum number of signs to show in a buffer.  Vim is slow at updating
 signs, so to avoid slowing down the GUI the number of signs is capped.  When
 the number of changed lines exceeds this value, the plugin removes all signs
 and displays a warning message.
+
+                                               *g:gitgutter_sign_allow_clobber*
+Default: 0
+
+When 1, allows GitGutter to adds its sign to the sign column despite the existence
+if signs from other plugins. This may clobber the signs from these other plugins.
 
                                           *g:gitgutter_sign_added*
                                           *g:gitgutter_sign_modified*

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -26,6 +26,7 @@ call s:set('g:gitgutter_enabled',                     1)
 call s:set('g:gitgutter_max_signs',                 500)
 call s:set('g:gitgutter_signs',                       1)
 call s:set('g:gitgutter_highlight_lines',             0)
+call s:set('g:gitgutter_sign_allow_clobber',          0)
 call s:set('g:gitgutter_sign_column_always',          0)
 if g:gitgutter_sign_column_always && exists('&signcolumn')
   " Vim 7.4.2201.


### PR DESCRIPTION
I have a patched Neovim that allows having multiple signs, so that clobbering naturally does not happen, thus vim-gitgutter does not need to avoid it.

https://github.com/neovim/neovim/issues/990