### PR TITLE
Correct typo in README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -288,9 +288,9 @@ You can either set these with `highlight GitGutterAdd {key}={arg}...` or link th
 To get vim-gitgutter's original colours (based on git-diff's colours in my terminal):
 
 ```viml
-highlight GitGutterAdd    guifg=#009900 guibg=<X> ctermfg=2 ctermb=<Y>
-highlight GitGutterChange guifg=#bbbb00 guibg=<X> ctermfg=3 ctermb=<Y>
-highlight GitGutterDelete guifg=#ff2222 guibg=<X> ctermfg=1 ctermb=<Y>
+highlight GitGutterAdd    guifg=#009900 guibg=<X> ctermfg=2 ctermbg=<Y>
+highlight GitGutterChange guifg=#bbbb00 guibg=<X> ctermfg=3 ctermbg=<Y>
+highlight GitGutterDelete guifg=#ff2222 guibg=<X> ctermfg=1 ctermbg=<Y>
 ```
 
 – where you would replace `<X>` and `<Y>` with the background colour of your `SignColumn` in the gui and the terminal respectively.  For example, with the solarized colorscheme and a dark background, `guibg=#073642` and `ctermbg=0`.


### PR DESCRIPTION
s/ctermb=<Y>/ctermbg=<Y>/