### PR TITLE
[RFC] process_buffer: call init_buffer with a:force

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -38,6 +38,10 @@ function! gitgutter#process_buffer(bufnr, force) abort
 
   if gitgutter#utility#is_active(a:bufnr)
     if a:force || s:has_fresh_changes(a:bufnr)
+      if a:force
+        let p = gitgutter#utility#repo_path(a:bufnr, 0)
+        call gitgutter#init_buffer(a:bufnr)
+      endif
 
       let diff = ''
       try


### PR DESCRIPTION
This is required to re-check if a buffer is tracked now, e.g. after
vim-fugitive's `:Gwrite`.

Test case:

1. have an untracked file, open it
2. gitgutter will not process it, setting "path" to -2
3. call `:Gwrite` to add the file to the index
4. change the buffer
5. signs are not being placed
6. call `:Gitgutter` manually
7. although it calls `gitgutter#process_buffer` with `a:force = 1`, it
   will still not display signs, since `gitgutter#diff#run_diff` throws
   "gitgutter not tracked".

A workaround is to call `gitgutter#init_buffer` yourself manually.

Additionally/instead vim-gitgutter could also call `init_buffer` on
`BufWritePost`, which gets triggered by vim-fugitive, but also on every
other write of course.