### PR TITLE
Refactor `set_repo_path` handling in async mode

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -10,8 +10,7 @@ function! gitgutter#all(force) abort
       let file = expand('#'.bufnr.':p')
       if !empty(file)
         if index(visible, bufnr) != -1
-          call gitgutter#init_buffer(bufnr)
-          call gitgutter#process_buffer(bufnr, a:force)
+          call gitgutter#init_buffer(bufnr, a:force)
         elseif a:force
           call s:reset_tick(bufnr)
         endif
@@ -22,13 +21,15 @@ endfunction
 
 
 " Finds the file's path relative to the repo root.
-function! gitgutter#init_buffer(bufnr)
+function! gitgutter#init_buffer(bufnr, ...) abort
   if gitgutter#utility#is_active(a:bufnr)
+    let force = a:0 ? a:1 : 0
     let p = gitgutter#utility#repo_path(a:bufnr, 0)
     if type(p) != s:t_string || empty(p)
       call gitgutter#utility#set_repo_path(a:bufnr)
       call s:setup_maps()
     endif
+    call gitgutter#process_buffer(a:bufnr, force)
   endif
 endfunction
 

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -26,10 +26,16 @@ function! gitgutter#init_buffer(bufnr, ...) abort
     let force = a:0 ? a:1 : 0
     let p = gitgutter#utility#repo_path(a:bufnr, 0)
     if type(p) != s:t_string || empty(p)
-      call gitgutter#utility#set_repo_path(a:bufnr)
+      let p = gitgutter#utility#set_repo_path(a:bufnr, force)
       call s:setup_maps()
+
+      " Process buffer, if not waiting for async.
+      if type(p) == s:t_string
+        call gitgutter#process_buffer(a:bufnr, force)
+      endif
+    else
+      call gitgutter#process_buffer(a:bufnr, force)
     endif
-    call gitgutter#process_buffer(a:bufnr, force)
   endif
 endfunction
 

--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -68,10 +68,6 @@ let s:counter = 0
 "                      the hunk headers (@@ -x,y +m,n @@); only possible if
 "                      grep is available.
 function! gitgutter#diff#run_diff(bufnr, from, preserve_full_diff) abort
-  while gitgutter#utility#repo_path(a:bufnr, 0) == -1
-    sleep 5m
-  endwhile
-
   if gitgutter#utility#repo_path(a:bufnr, 0) == -2
     throw 'gitgutter not tracked'
   endif

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -142,14 +142,17 @@ function! gitgutter#utility#set_repo_path(bufnr) abort
               \ })
       endif
     endif
+    let ret = -1
   else
     let path = gitgutter#utility#system(cmd)
     if v:shell_error
-      call gitgutter#utility#setbufvar(a:bufnr, 'path', -2)
+      let ret = -2
     else
-      call gitgutter#utility#setbufvar(a:bufnr, 'path', s:strip_trailing_new_line(path))
+      let ret = s:strip_trailing_new_line(path)
     endif
+    call gitgutter#utility#setbufvar(a:bufnr, 'path', ret)
   endif
+  return ret
 endfunction
 
 if has('nvim') && !has('nvim-0.2.0')

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -190,8 +190,7 @@ function! s:on_bufenter()
     let t:gitgutter_didtabenter = 0
     call gitgutter#all(!g:gitgutter_terminal_reports_focus)
   else
-    call gitgutter#init_buffer(bufnr(''))
-    call gitgutter#process_buffer(bufnr(''), !g:gitgutter_terminal_reports_focus)
+    call gitgutter#init_buffer(bufnr(''), 0)
   endif
 endfunction
 


### PR DESCRIPTION
Please see the commits - I've tried to split it into smaller refactoring steps.

The main benefit is, that the sleep-loop gets removed, and the async's job callback calls `process_buffer` instead.

Only slightly tested.