### PR TITLE
Add g:gitgutter_preview_win_location option to control preview popup location

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -255,7 +255,7 @@ function! s:preview(hunk_diff)
 
   silent! wincmd P
   if !&previewwindow
-    noautocmd execute 'bo' previewheight 'new'
+    noautocmd execute g:gitgutter_preview_win_location previewheight 'new'
     set previewwindow
   else
     execute 'resize' previewheight

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -270,6 +270,12 @@ General:~
     |g:gitgutter_log|
 
 
+                                             *g:gitgutter_preview_win_location*
+Default: 'bo'
+
+This option determines where the preview window pops up as a result of the
+:GitGutterPreviewHunk command. Other plausible values are 'to', 'bel', 'abo'.
+
                                                    *g:gitgutter_git_executable*
 Default: 'git'
 

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -22,6 +22,7 @@ function! s:set(var, default) abort
   endif
 endfunction
 
+call s:set('g:gitgutter_preview_win_location',     'bo')
 call s:set('g:gitgutter_enabled',                     1)
 call s:set('g:gitgutter_max_signs',                 500)
 call s:set('g:gitgutter_signs',                       1)


### PR DESCRIPTION
The default preview window location is `bo`. This commit adds a global variable `g:gitgutter_preview_win_location` that enables other settings such as `to`, `bel` and `abo`.