### PR TITLE
gitgutter#utility#getbufvar: handle not existing buffer

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -22,13 +22,14 @@ function! gitgutter#utility#setbufvar(buffer, varname, val)
 endfunction
 
 function! gitgutter#utility#getbufvar(buffer, varname, ...)
-  let dict = get(getbufvar(a:buffer, ''), 'gitgutter', {})
-  if has_key(dict, a:varname)
-    return dict[a:varname]
-  else
-    if a:0
-      return a:1
+  if bufexists(a:buffer)
+    let dict = get(getbufvar(a:buffer, ''), 'gitgutter', {})
+    if has_key(dict, a:varname)
+      return dict[a:varname]
     endif
+  endif
+  if a:0
+    return a:1
   endif
 endfunction
 

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -22,8 +22,9 @@ function! gitgutter#utility#setbufvar(buffer, varname, val)
 endfunction
 
 function! gitgutter#utility#getbufvar(buffer, varname, ...)
-  if bufexists(a:buffer)
-    let dict = get(getbufvar(a:buffer, ''), 'gitgutter', {})
+  let bvars = getbufvar(a:buffer, '')
+  if !empty(bvars)
+    let dict = get(bvars, 'gitgutter', {})
     if has_key(dict, a:varname)
       return dict[a:varname]
     endif


### PR DESCRIPTION
`getbufvar(a:buffer, '')` returns '' then, resulting in an error.