### PR TITLE
Add `numhl` for signs

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -17,7 +17,8 @@ Features:
 * Allows folding all unchanged text.
 * Handles line endings correctly, even with repos that do CRLF conversion.
 * Optional line highlighting.
-* Fully customisable (signs, sign column, line highlights, mappings, extra git-diff arguments, etc).
+* Optional line number highlighting. (Only available in Neovim 0.3.2 or higher)
+* Fully customisable (signs, sign column, line (number) highlights, mappings, extra git-diff arguments, etc).
 * Can be toggled on/off, globally or per buffer.
 * Preserves signs from other plugins.
 * Easy to integrate diff stats into status line; built-in integration with [vim-airline](https://github.com/bling/vim-airline/).
@@ -138,6 +139,12 @@ And you can turn line highlighting on and off (defaults to off):
 * turn off with `:GitGutterLineHighlightsDisable`
 * toggle with `:GitGutterLineHighlightsToggle`.
 
+With Neovim 0.3.2 or higher, you can turn line number highlighting on and off (defaults to off):
+
+* turn on with `:GitGutterLineNrHighlightsEnable`
+* turn off with `:GitGutterLineNrHighlightsDisable`
+* toggle with `:GitGutterLineNrHighlightsToggle`.
+
 Note that if you have line highlighting on and signs off, you will have an empty sign column – more accurately, a sign column with invisible signs.  This is because line highlighting requires signs and Vim always shows the sign column even if the signs are invisible.
 
 If you switch off both line highlighting and signs, you won't see the sign column.  That is unless you configure the sign column always to be there (see Sign Column section).
@@ -233,6 +240,7 @@ You can customise:
 * Whether or not vim-gitgutter is on initially (defaults to on)
 * Whether or not signs are shown (defaults to yes)
 * Whether or not line highlighting is on initially (defaults to off)
+* Whether or not line number highlighting is on initially (defaults to off)
 * Whether or not vim-gitgutter runs in "realtime" (defaults to yes)
 * Whether or not vim-gitgutter runs eagerly (defaults to yes)
 * Whether or not vim-gitgutter runs asynchronously (defaults to yes)
@@ -324,6 +332,26 @@ highlight link GitGutterChangeLine DiffText
 ```
 
 
+#### Line number highlights
+
+NOTE: This feature requires Neovim 0.3.2 or higher.
+
+Similarly to the signs' colours, set up the following highlight groups in your colorscheme or `~/.vimrc`:
+
+```viml
+GitGutterAddLineNr          " default: links to CursorLineNr
+GitGutterChangeLineNr       " default: links to CursorLineNr
+GitGutterDeleteLineNr       " default: links to CursorLineNr
+GitGutterChangeDeleteLineNr " default: links to CursorLineNr
+```
+
+Maybe you think `CursorLineNr` is a bit annoying.  For example, you could use `Underlined` for this:
+
+```viml
+highlight link GitGutterChangeLineNr Underlined
+```
+
+
 #### The base of the diff
 
 By default buffers are diffed against the index.  However you can diff against any commit by setting:
@@ -382,6 +410,11 @@ Add `let g:gitgutter_signs = 0` to your `~/.vimrc`.
 #### To turn on line highlighting by default
 
 Add `let g:gitgutter_highlight_lines = 1` to your `~/.vimrc`.
+
+
+#### To turn on line number highlighting by default
+
+Add `let g:gitgutter_highlight_linenrs = 1` to your `~/.vimrc`.
 
 
 #### To turn off asynchronous updates

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -31,6 +31,39 @@ function! gitgutter#highlight#line_toggle() abort
   endif
 endfunction
 
+function! gitgutter#highlight#linenr_disable() abort
+  let g:gitgutter_highlight_linenrs = 0
+  call s:define_sign_linenr_highlights()
+
+  if !g:gitgutter_signs
+    call gitgutter#sign#clear_signs(bufnr(''))
+    call gitgutter#sign#remove_dummy_sign(bufnr(''), 0)
+  endif
+
+  redraw!
+endfunction
+
+function! gitgutter#highlight#linenr_enable() abort
+  let old_highlight_lines = g:gitgutter_highlight_linenrs
+
+  let g:gitgutter_highlight_linenrs = 1
+  call s:define_sign_linenr_highlights()
+
+  if !old_highlight_lines && !g:gitgutter_signs
+    call gitgutter#all(1)
+  endif
+
+  redraw!
+endfunction
+
+function! gitgutter#highlight#linenr_toggle() abort
+  if g:gitgutter_highlight_linenrs
+    call gitgutter#highlight#linenr_disable()
+  else
+    call gitgutter#highlight#linenr_enable()
+  endif
+endfunction
+
 
 function! gitgutter#highlight#define_sign_column_highlight() abort
   if g:gitgutter_override_sign_column_highlight
@@ -66,6 +99,11 @@ function! gitgutter#highlight#define_highlights() abort
   highlight default link GitGutterChangeLine       DiffChange
   highlight default link GitGutterDeleteLine       DiffDelete
   highlight default link GitGutterChangeDeleteLine GitGutterChangeLine
+
+  highlight default link GitGutterAddLineNr          CursorLineNr
+  highlight default link GitGutterChangeLineNr       CursorLineNr
+  highlight default link GitGutterDeleteLineNr       CursorLineNr
+  highlight default link GitGutterChangeDeleteLineNr CursorLineNr
 endfunction
 
 function! gitgutter#highlight#define_signs() abort
@@ -80,6 +118,7 @@ function! gitgutter#highlight#define_signs() abort
   call s:define_sign_text()
   call gitgutter#highlight#define_sign_text_highlights()
   call s:define_sign_line_highlights()
+  call s:define_sign_linenr_highlights()
 endfunction
 
 function! s:define_sign_text() abort
@@ -128,6 +167,17 @@ function! s:define_sign_line_highlights() abort
     sign define GitGutterLineRemovedFirstLine      linehl=
     sign define GitGutterLineRemovedAboveAndBelow  linehl=
     sign define GitGutterLineModifiedRemoved       linehl=
+  endif
+endfunction
+
+function! s:define_sign_linenr_highlights() abort
+  if g:gitgutter_highlight_linenrs && has('nvim-0.3.2')
+    sign define GitGutterLineAdded                 numhl=GitGutterAddLineNr
+    sign define GitGutterLineModified              numhl=GitGutterChangeLineNr
+    sign define GitGutterLineRemoved               numhl=GitGutterDeleteLineNr
+    sign define GitGutterLineRemovedFirstLine      numhl=GitGutterDeleteLineNr
+    sign define GitGutterLineRemovedAboveAndBelow  numhl=GitGutterDeleteLineNr
+    sign define GitGutterLineModifiedRemoved       numhl=GitGutterChangeDeleteLineNr
   endif
 endfunction
 

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -171,13 +171,22 @@ function! s:define_sign_line_highlights() abort
 endfunction
 
 function! s:define_sign_linenr_highlights() abort
-  if g:gitgutter_highlight_linenrs && has('nvim-0.3.2')
-    sign define GitGutterLineAdded                 numhl=GitGutterAddLineNr
-    sign define GitGutterLineModified              numhl=GitGutterChangeLineNr
-    sign define GitGutterLineRemoved               numhl=GitGutterDeleteLineNr
-    sign define GitGutterLineRemovedFirstLine      numhl=GitGutterDeleteLineNr
-    sign define GitGutterLineRemovedAboveAndBelow  numhl=GitGutterDeleteLineNr
-    sign define GitGutterLineModifiedRemoved       numhl=GitGutterChangeDeleteLineNr
+  if has('nvim-0.3.2')
+    if g:gitgutter_highlight_linenrs
+      sign define GitGutterLineAdded                 numhl=GitGutterAddLineNr
+      sign define GitGutterLineModified              numhl=GitGutterChangeLineNr
+      sign define GitGutterLineRemoved               numhl=GitGutterDeleteLineNr
+      sign define GitGutterLineRemovedFirstLine      numhl=GitGutterDeleteLineNr
+      sign define GitGutterLineRemovedAboveAndBelow  numhl=GitGutterDeleteLineNr
+      sign define GitGutterLineModifiedRemoved       numhl=GitGutterChangeDeleteLineNr
+    else
+      sign define GitGutterLineAdded                 numhl=
+      sign define GitGutterLineModified              numhl=
+      sign define GitGutterLineRemoved               numhl=
+      sign define GitGutterLineRemovedFirstLine      numhl=
+      sign define GitGutterLineRemovedAboveAndBelow  numhl=
+      sign define GitGutterLineModifiedRemoved       numhl=
+    endif
   endif
 endfunction
 

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -126,6 +126,19 @@ Commands for turning line highlighting on and off (defaults to off):~
 :GitGutterLineHighlightsToggle  Turn line highlighting on or off.
 
 
+Commands for turning line number highlighting on and off (defaults to off):~
+NOTE: This feature requires Neovim 0.3.2 or higher.
+
+                                   *gitgutter-:GitGutterLineNrHighlightsEnable*
+:GitGutterLineNrHighlightsEnable  Turn on line highlighting.
+
+                                  *gitgutter-:GitGutterLineNrHighlightsDisable*
+:GitGutterLineNrHighlightsDisable Turn off line highlighting.
+
+                                   *gitgutter-:GitGutterLineNrHighlightsToggle*
+:GitGutterLineNrHighlightsToggle  Turn line highlighting on or off.
+
+
 Commands for jumping between hunks:~
 
                                                  *gitgutter-:GitGutterNextHunk*
@@ -249,6 +262,7 @@ Signs:~
 
     |g:gitgutter_signs|
     |g:gitgutter_highlight_lines|
+    |g:gitgutter_highlight_linenrs|
     |g:gitgutter_max_signs|
     |g:gitgutter_sign_added|
     |g:gitgutter_sign_modified|
@@ -328,6 +342,11 @@ Determines whether or not to show signs.
 Default: 0
 
 Determines whether or not to show line highlights.
+
+                                                *g:gitgutter_highlight_linenrs*
+Default: 0
+
+Determines whether or not to show line number highlights.
 
                                                         *g:gitgutter_max_signs*
 Default: 500
@@ -458,6 +477,18 @@ colorscheme or |vimrc|:
 For example, to use |hl-DiffText| instead of |hl-DiffChange|:
 >
     highlight link GitGutterChangeLine DiffChange
+<
+To change the line number highlights, set up the following highlight groups in
+your colorscheme or |vimrc|:
+>
+    GitGutterAddLineNr          " default: links to CursorLineNr
+    GitGutterChangeLineNr       " default: links to CursorLineNr
+    GitGutterDeleteLineNr       " default: links to CursorLineNr
+    GitGutterChangeDeleteLineNr " default: links to CursorLineNr
+<
+For example, to use |hl-Underlined| instead of |hl-CursorLineNr|:
+>
+    highlight link GitGutterChangeLineNr Underlined
 <
 
 

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -476,7 +476,7 @@ colorscheme or |vimrc|:
 
 For example, to use |hl-DiffText| instead of |hl-DiffChange|:
 >
-    highlight link GitGutterChangeLine DiffChange
+    highlight link GitGutterChangeLine DiffText
 <
 To change the line number highlights, set up the following highlight groups in
 your colorscheme or |vimrc|:

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -26,6 +26,7 @@ call s:set('g:gitgutter_enabled',                     1)
 call s:set('g:gitgutter_max_signs',                 500)
 call s:set('g:gitgutter_signs',                       1)
 call s:set('g:gitgutter_highlight_lines',             0)
+call s:set('g:gitgutter_highlight_linenrs',           0)
 call s:set('g:gitgutter_sign_column_always',          0)
 if g:gitgutter_sign_column_always && exists('&signcolumn')
   " Vim 7.4.2201.

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -112,6 +112,12 @@ command! -bar GitGutterLineHighlightsToggle  call gitgutter#highlight#line_toggl
 
 " }}}
 
+" 'number' column highlights {{{
+command! -bar GitGutterLineNrHighlightsDisable call gitgutter#highlight#linenr_disable()
+command! -bar GitGutterLineNrHighlightsEnable  call gitgutter#highlight#linenr_enable()
+command! -bar GitGutterLineNrHighlightsToggle  call gitgutter#highlight#linenr_toggle()
+" }}}
+
 " Signs {{{
 
 command! -bar GitGutterSignsEnable  call gitgutter#sign#enable()


### PR DESCRIPTION
Neovim has `numhl` option for signs. This PR adds highlights for this.

https://github.com/neovim/neovim/commit/bddcbbb5716a005001da3bacb4c1df4ae05e51bc

<img width="319" alt="スクリーンショット 0001-07-04 22 41 24" src="https://user-images.githubusercontent.com/1239245/60670957-eaa8b800-9eac-11e9-93f5-c4671273c8ed.png">

* Added a new option `g:gitgutter_highlight_linenrs` (default: `0`).
* Added highlights `GitGutter(Add|Change|Delete|ChangeDelete)LineNr`.
  * All are linked to `CursorLineNr`.

If you like it, I will add help for these.