### PR TITLE
Remove empty last line of hunk previews

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -264,6 +264,7 @@ function! s:preview(hunk_diff)
   setlocal noreadonly modifiable filetype=diff buftype=nofile bufhidden=delete noswapfile
   execute "%delete_"
   call append(0, hunk_lines)
+  execute '$delete'
   normal! gg
   setlocal readonly nomodifiable
 


### PR DESCRIPTION
When you delete all lines, a single empty line always remains. When you append the new lines, that empty line goes to the bottom of the file.

I thought I had already reported this bug before and it had been fixed... Maybe I'm misremembering.