### PR TITLE
Fix #639: Use more careful way to enable `numhl`

### DIFF
--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -172,21 +172,24 @@ endfunction
 
 function! s:define_sign_linenr_highlights() abort
   if has('nvim-0.3.2')
-    if g:gitgutter_highlight_linenrs
-      sign define GitGutterLineAdded                 numhl=GitGutterAddLineNr
-      sign define GitGutterLineModified              numhl=GitGutterChangeLineNr
-      sign define GitGutterLineRemoved               numhl=GitGutterDeleteLineNr
-      sign define GitGutterLineRemovedFirstLine      numhl=GitGutterDeleteLineNr
-      sign define GitGutterLineRemovedAboveAndBelow  numhl=GitGutterDeleteLineNr
-      sign define GitGutterLineModifiedRemoved       numhl=GitGutterChangeDeleteLineNr
-    else
-      sign define GitGutterLineAdded                 numhl=
-      sign define GitGutterLineModified              numhl=
-      sign define GitGutterLineRemoved               numhl=
-      sign define GitGutterLineRemovedFirstLine      numhl=
-      sign define GitGutterLineRemovedAboveAndBelow  numhl=
-      sign define GitGutterLineModifiedRemoved       numhl=
-    endif
+    try
+      if g:gitgutter_highlight_linenrs
+          sign define GitGutterLineAdded                 numhl=GitGutterAddLineNr
+          sign define GitGutterLineModified              numhl=GitGutterChangeLineNr
+          sign define GitGutterLineRemoved               numhl=GitGutterDeleteLineNr
+          sign define GitGutterLineRemovedFirstLine      numhl=GitGutterDeleteLineNr
+          sign define GitGutterLineRemovedAboveAndBelow  numhl=GitGutterDeleteLineNr
+          sign define GitGutterLineModifiedRemoved       numhl=GitGutterChangeDeleteLineNr
+      else
+        sign define GitGutterLineAdded                 numhl=
+        sign define GitGutterLineModified              numhl=
+        sign define GitGutterLineRemoved               numhl=
+        sign define GitGutterLineRemovedFirstLine      numhl=
+        sign define GitGutterLineRemovedAboveAndBelow  numhl=
+        sign define GitGutterLineModifiedRemoved       numhl=
+      endif
+    catch /E475/
+    endtry
   endif
 endfunction
 


### PR DESCRIPTION
The development versions of v0.3.2 also report `has('nvim-0.3.2')` to be
true even if they do not support the `numhl` feature. So here it catches
and ignores the possible errors.