### PR TITLE
Add neovim hunk preview floating window

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -269,6 +269,7 @@ You can customise:
 * Whether vim-gitgutter runs asynchronously (defaults to yes)
 * Whether to clobber or preserve non-gitgutter signs
 * The priority of gitgutter's signs.
+* Whether vim-gitgutter should use floating windows for hunk preview (defaults to no)
 
 Please note that vim-gitgutter won't override any colours or highlights you've set in your colorscheme.
 
@@ -452,6 +453,11 @@ By default diffs are run asynchronously.  To run diffs synchronously instead:
 ```viml
 let g:gitgutter_async = 0
 ```
+
+#### To use floating windows for hunk preview
+
+By default hunk preview uses preview window. Make sure floating windows is supported.
+Add `let g:gitgutter_preview_win_floating = 1` to your `~/.vimrc`
 
 
 ### Extensions

--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -300,7 +300,7 @@ function! s:preview(hunk_diff)
   let body_length = len(body)
   let previewheight = min([body_length, &previewheight])
 
-  if has('nvim') && exists('*nvim_open_win')
+  if g:gitgutter_preview_win_floating && has('nvim') && exists('*nvim_open_win')
     let buf = nvim_create_buf(v:false, v:false)
     let width = max(map(copy(body), 'strdisplaywidth(v:val)'))
     let height = body_length + (width / &columns)

--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -302,8 +302,8 @@ function! s:preview(hunk_diff)
 
   if has('nvim') && exists('*nvim_open_win')
     let buf = nvim_create_buf(v:false, v:false)
-    let width = max(map(copy(lines), 'strdisplaywidth(v:val)'))
-    let height = len(lines)
+    let width = max(map(copy(body), 'strdisplaywidth(v:val)'))
+    let height = body_length + (width / &columns)
 
     let s:floating_win = nvim_open_win(
           \ buf, v:true, {
@@ -328,7 +328,6 @@ function! s:preview(hunk_diff)
 
   let b:hunk_header = header
 
-  setlocal noreadonly modifiable filetype=diff buftype=nofile bufhidden=delete noswapfile
   setlocal noreadonly modifiable filetype=diff buftype=nofile bufhidden=delete noswapfile nospell
   execute "%delete_"
   call setline(1, body)

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -22,6 +22,7 @@ function! s:set(var, default) abort
   endif
 endfunction
 
+call s:set('g:gitgutter_preview_win_floating',        0)
 call s:set('g:gitgutter_preview_win_location',     'bo')
 call s:set('g:gitgutter_enabled',                     1)
 call s:set('g:gitgutter_max_signs',                 500)


### PR DESCRIPTION
This uses floating windows introduced in neovim to display hunks instead of
preview windows. Requires nvim with floating windows.

If nvim is running and has floating window capabilities, display hunk
preview in a floating window instead of a preview windows. Then a user
can focus to that floating window with Ctrl-w to be able to scroll if
needed to. Moving the cursor in the current buffer closes the floating
window or `:q` inside the floating window.

#643 

![render1566093464359](https://user-images.githubusercontent.com/3187948/63219206-ce01d000-c13a-11e9-92c1-2b6ed6c47168.gif)

I'm also using this in my config to override `diff` filetype background color.
```
highlight DiffAdded ctermbg=none
highlight DiffRemoved ctermbg=none
```