### PR TITLE
Fix preview-floatwin with Vim: use doautocmd FileType

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -422,7 +422,7 @@ function! s:open_hunk_preview_window()
             \ })
 
       call setbufvar(winbufnr(s:winid), '&filetype', 'diff')
-      call win_execute(s:winid, 'syntax enable')
+      call win_execute(s:winid, 'doautocmd FileType')
 
       return
     endif


### PR DESCRIPTION
Using "syntax enable" might trigger netrw for unknown reasons, resulting
in an error.

Fixes https://github.com/airblade/vim-gitgutter/issues/653.