### PR TITLE
Fix example mappings

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -142,11 +142,9 @@ Both of those take a preceding count.
 
 To set your own mappings for these, for example `]h` and `[h`:
 
-In the lines below I have deleted brackets around GitGutter{Next,Prev}Hunk:
-
 ```viml
-nmap ]h <Plug>GitGutterNextHunk
-nmap [h <Plug>GitGutterPrevHunk
+nmap ]h <Plug>(GitGutterNextHunk)
+nmap [h <Plug>(GitGutterPrevHunk)
 ```
 
 You can load all your hunks into the quickfix list with `:GitGutterQuickFix`.  Note this ignores any unsaved changes in your buffers.


### PR DESCRIPTION
I'm guessing this change was made to demonstrate the functionality shown in the screenshot (this change was introduced at the same time the screenshot and associated description was updated, in commit 6660aca9476b7ddd209cbda0329a59904eda53ed), but since these mappings don't actually work (and indeed emit warnings), I'm guessing that change was inadvertently committed.