### PR TITLE
Add g:gitgutter_use_location_list option

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -18,7 +18,7 @@ Features:
 * Diffs against index (default) or any commit.
 * Allows folding all unchanged text.
 * Provides fold text showing whether folded lines have been changed.
-* Can load all hunk locations into quickfix list.
+* Can load all hunk locations into quickfix list or the current window's location list.
 * Handles line endings correctly, even with repos that do CRLF conversion.
 * Optional line highlighting.
 * Optional line number highlighting. (Only available in Neovim 0.3.2 or higher)
@@ -147,7 +147,7 @@ nmap ]h <Plug>(GitGutterNextHunk)
 nmap [h <Plug>(GitGutterPrevHunk)
 ```
 
-You can load all your hunks into the quickfix list with `:GitGutterQuickFix`.  Note this ignores any unsaved changes in your buffers.
+You can load all your hunks into the quickfix list with `:GitGutterQuickFix`.  Note this ignores any unsaved changes in your buffers. If the option `g:gitgutter_use_location_list` is set, this command will load hunks into the current window's location list instead.
 
 You can stage or undo an individual hunk when your cursor is in it:
 
@@ -254,6 +254,7 @@ You can customise:
 * Whether to clobber or preserve non-gitgutter signs
 * The priority of gitgutter's signs.
 * Whether to use a floating/popup window for hunk previews
+* Whether to populate the quickfix list or a location list with all hunks
 
 Please note that vim-gitgutter won't override any colours or highlights you've set in your colorscheme.
 
@@ -452,7 +453,12 @@ let g:gitgutter_async = 0
 
 #### To use floating/popup windows for hunk previews
 
-Add `let g:gitgutter_preview_win_floating = 1` to your vimrc.  Note that on Vim this prevents you staging (partial) hunks via the preview window.
+Add `let g:gitgutter_preview_win_floating = 1` to your `~/.vimrc`.  Note that on Vim this prevents you staging (partial) hunks via the preview window.
+
+
+#### To load all hunks into the current window's location list instead of the quickfix list
+
+Add `let g:gitgutter_use_location_list = 1` to your `~/.vimrc`.
 
 
 ### Extensions
@@ -515,7 +521,7 @@ Let's say, for example, you want to remove trailing whitespace from all changed 
 
 #### Cycle through hunks in all buffers
 
-You can use `:GitGutterQuickFix` to load all hunks into the quickfix list.
+You can use `:GitGutterQuickFix` to load all hunks into the quickfix list or the current window's location list.
 
 Alternatively, given that`]c` and `[c` jump from one hunk to the next in the current buffer, you can use this code to jump to the next hunk no matter which buffer it's in.
 

--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -207,5 +207,9 @@ function! gitgutter#quickfix()
       let lnum = 0
     endif
   endfor
-  call setqflist(locations)
+  if !g:gitgutter_use_location_list
+    call setqflist(locations)
+  else
+    call setloclist(0, locations)
+  endif
 endfunction

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -140,7 +140,9 @@ Commands for jumping between hunks:~
 
                                                  *gitgutter-:GitGutterQuickFix*
 :GitGutterQuickFix      Load all hunks into the |quickfix| list.  Note this
-                        ignores any unsaved changes in your buffers.
+                        ignores any unsaved changes in your buffers. The
+                        |g:gitgutter_use_location_list| option can be set to
+                        populate the location list of the current window instead
 
 
 Commands for operating on a hunk:~
@@ -294,6 +296,7 @@ General:~
     |g:gitgutter_map_keys|
     |g:gitgutter_async|
     |g:gitgutter_log|
+    |g:gitgutter_use_location_list|
 
 
                                              *g:gitgutter_preview_win_location*
@@ -486,6 +489,12 @@ Default: 0
 
 When switched on, the plugin logs to gitgutter.log in the directory where it is
 installed.  Additionally it logs channel activity to channel.log.
+
+                                                *g:gitgutter_use_location_list*
+Default: 0
+
+When switched on, the :GitGutterQuickFix command populates the location list
+of the current window instead of the global quickfix list.
 
 
 ===============================================================================

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -61,6 +61,7 @@ call s:set('g:gitgutter_map_keys',                       1)
 call s:set('g:gitgutter_terminal_reports_focus',         1)
 call s:set('g:gitgutter_async',                          1)
 call s:set('g:gitgutter_log',                            0)
+call s:set('g:gitgutter_use_location_list',              0)
 
 call s:set('g:gitgutter_git_executable', 'git')
 if !executable(g:gitgutter_git_executable)


### PR DESCRIPTION
Thought it would be useful to others to have this fix that I wrote for myself. I use the global quickfix list to hold compiler errors, which I don't want to have clobbered by other things such as `:grep` and `:GitGutterQuickFix`. Also, I think semantically, this makes more sense anyways, these are locations in the code, not fixable items.