### PR TITLE
Check if `termencoding` exist before using it

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -1,5 +1,5 @@
 function! gitgutter#utility#supports_overscore_sign()
-  if gitgutter#utility#windows()
+  if gitgutter#utility#windows() || !exists('+termencoding')
     return &encoding ==? 'utf-8'
   else
     return &termencoding ==? &encoding || &termencoding == ''


### PR DESCRIPTION
Neovim removed `termencoding` support a long time ago, but it only started failing yesterday, with the release of v0.5.0 (I'm yet to pinpoint exact change). This PR modifies `gitgutter#utility#supports_overscore_sign` so that it checks whether `termencoding` exists at all (in the spirit of this [PR to Tagbar](https://github.com/majutsushi/tagbar/pull/575)).

Fixes #670 .