### PR TITLE
fix the behavior of the status line of the hunk preview windows

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -435,7 +435,8 @@ function! s:open_hunk_preview_window()
 
   silent! wincmd P
   if !&previewwindow
-    execute g:gitgutter_preview_win_location &previewheight 'new gitgutter://hunk-preview'
+    noautocmd execute g:gitgutter_preview_win_location &previewheight 'new gitgutter://hunk-preview'
+    doautocmd WinEnter gitgutter://hunk-preview
     let s:winid = win_getid()
     set previewwindow
     setlocal filetype=diff buftype=acwrite bufhidden=delete
@@ -511,7 +512,7 @@ endfunction
 
 
 function! s:goto_original_window()
-  wincmd p
+  noautocmd wincmd p
 endfunction
 
 

--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -435,7 +435,7 @@ function! s:open_hunk_preview_window()
 
   silent! wincmd P
   if !&previewwindow
-    noautocmd execute g:gitgutter_preview_win_location &previewheight 'new gitgutter://hunk-preview'
+    execute g:gitgutter_preview_win_location &previewheight 'new gitgutter://hunk-preview'
     let s:winid = win_getid()
     set previewwindow
     setlocal filetype=diff buftype=acwrite bufhidden=delete
@@ -511,7 +511,7 @@ endfunction
 
 
 function! s:goto_original_window()
-  noautocmd wincmd p
+  wincmd p
 endfunction
 
 


### PR DESCRIPTION
A fix to #688.

I removed `noautocmd` from the line that open the preview window and the line who moves back the cursor to the original window.

Like as said in the vim help about `noautocmd`: 

> To disable autocommands for just one command use the ":noautocmd" command modifier.  **This will set 'eventignore' to "all" for the duration of the following command.**

That is why the status line of the preview window is not updated as expected because the events are not emitted and so plugins like lightline cannot update the status line because they can't handle the relevant events.