### PR TITLE
fix #688

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -436,7 +436,7 @@ function! s:open_hunk_preview_window()
   silent! wincmd P
   if !&previewwindow
     noautocmd execute g:gitgutter_preview_win_location &previewheight 'new gitgutter://hunk-preview'
-    doautocmd WinEnter gitgutter://hunk-preview
+    doautocmd WinEnter
     let s:winid = win_getid()
     set previewwindow
     setlocal filetype=diff buftype=acwrite bufhidden=delete
@@ -513,6 +513,7 @@ endfunction
 
 function! s:goto_original_window()
   noautocmd wincmd p
+  doautocmd WinEnter
 endfunction
 
 


### PR DESCRIPTION
fix issue #688

Sorry, I forgot to trigger `WinEnter` once the switch from the window preview to the original window is done. It's ok now.

However, the opening of windows or switch between them seem to trigger lot of events which may be tracked or required by other plugins or vim itself. I don't know if the use of `noautocmd` before critical action is a good idea.