### PR TITLE
"No hunk in file" when no previous nor next hunk

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -58,7 +58,7 @@ function! gitgutter#hunk#next_hunk(count) abort
       endif
     endfor
     if gitgutter#hunk#summary(bufnr) == [0,0,0]
-        call gitgutter#utility#warn('No hunk in file')
+      call gitgutter#utility#warn('No hunk in file')
     else
       call gitgutter#utility#warn('No more hunks')
     endif
@@ -81,7 +81,7 @@ function! gitgutter#hunk#prev_hunk(count) abort
       endif
     endfor
     if gitgutter#hunk#summary(bufnr) == [0,0,0]
-        call gitgutter#utility#warn('No hunk in file')
+      call gitgutter#utility#warn('No hunk in file')
     else
       call gitgutter#utility#warn('No previous hunks')
     endif

--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -43,32 +43,6 @@ function! gitgutter#hunk#increment_lines_removed(bufnr, count) abort
   call gitgutter#utility#setbufvar(a:bufnr, 'summary', summary)
 endfunction
 
-function! gitgutter#hunk#next_hunk_check(count) abort
-  let bufnr = bufnr('')
-  if gitgutter#utility#is_active(bufnr)
-    let current_line = line('.')
-    for hunk in gitgutter#hunk#hunks(bufnr)
-      if hunk[2] > current_line
-      return 1
-      endif
-    endfor
-    return 0
-  endif
-endfunction
-
-function! gitgutter#hunk#prev_hunk_check(count) abort
-  let bufnr = bufnr('')
-  if gitgutter#utility#is_active(bufnr)
-    let current_line = line('.')
-    for hunk in reverse(copy(gitgutter#hunk#hunks(bufnr)))
-      if hunk[2] < current_line
-        return 1
-      endif
-    endfor
-    return 0
-  endif
-endfunction
-
 function! gitgutter#hunk#next_hunk(count) abort
   let bufnr = bufnr('')
   if gitgutter#utility#is_active(bufnr)
@@ -83,7 +57,7 @@ function! gitgutter#hunk#next_hunk(count) abort
         endif
       endif
     endfor
-    if gitgutter#hunk#prev_hunk_check(0) == 0
+    if gitgutter#hunk#summary(bufnr) == [0,0,0]
         call gitgutter#utility#warn('No hunk in file')
     else
       call gitgutter#utility#warn('No more hunks')
@@ -106,7 +80,7 @@ function! gitgutter#hunk#prev_hunk(count) abort
         endif
       endif
     endfor
-    if gitgutter#hunk#next_hunk_check(0) == 0
+    if gitgutter#hunk#summary(bufnr) == [0,0,0]
         call gitgutter#utility#warn('No hunk in file')
     else
       call gitgutter#utility#warn('No previous hunks')

--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -43,6 +43,31 @@ function! gitgutter#hunk#increment_lines_removed(bufnr, count) abort
   call gitgutter#utility#setbufvar(a:bufnr, 'summary', summary)
 endfunction
 
+function! gitgutter#hunk#next_hunk_check(count) abort
+  let bufnr = bufnr('')
+  if gitgutter#utility#is_active(bufnr)
+    let current_line = line('.')
+    for hunk in gitgutter#hunk#hunks(bufnr)
+      if hunk[2] > current_line
+      return 1
+      endif
+    endfor
+    return 0
+  endif
+endfunction
+
+function! gitgutter#hunk#prev_hunk_check(count) abort
+  let bufnr = bufnr('')
+  if gitgutter#utility#is_active(bufnr)
+    let current_line = line('.')
+    for hunk in reverse(copy(gitgutter#hunk#hunks(bufnr)))
+      if hunk[2] < current_line
+        return 1
+      endif
+    endfor
+    return 0
+  endif
+endfunction
 
 function! gitgutter#hunk#next_hunk(count) abort
   let bufnr = bufnr('')
@@ -58,7 +83,11 @@ function! gitgutter#hunk#next_hunk(count) abort
         endif
       endif
     endfor
-    call gitgutter#utility#warn('No more hunks')
+    if gitgutter#hunk#prev_hunk_check(0) == 0
+        call gitgutter#utility#warn('No hunk in file')
+    else
+      call gitgutter#utility#warn('No more hunks')
+    endif
   endif
 endfunction
 
@@ -77,7 +106,11 @@ function! gitgutter#hunk#prev_hunk(count) abort
         endif
       endif
     endfor
-    call gitgutter#utility#warn('No previous hunks')
+    if gitgutter#hunk#next_hunk_check(0) == 0
+        call gitgutter#utility#warn('No hunk in file')
+    else
+      call gitgutter#utility#warn('No previous hunks')
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
As I often just want to check if there's a hunk, I though that a different message should be displayed when there's no hunk in the file.

I couldn't find a simple way to check if hunks are present in the file, and I wonder if such a small change deserves 30 lines of code.

I had to modify both **gitgutter#hunk#prev_hunk** and **gitgutter#hunk#next_hunk** functions to check for previous or next hunk, and display the message accordingly.

For the check, I added their counterparts **gitgutter#hunk#prev_hunk_check** and **gitgutter#hunk#next_hunk_check** (using the same algorithm).
