### PR TITLE
fix full-width characters to half-width characters

### DIFF
--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -446,7 +446,7 @@ Defaults:
     let g:gitgutter_sign_modified           = '~'
     let g:gitgutter_sign_removed            = '_'
     let g:gitgutter_sign_removed_first_line = '‾'
-    let g:gitgutter_sign_removed_above_and_below = '_‾'
+    let g:gitgutter_sign_removed_above_and_below = '_¯'
     let g:gitgutter_sign_modified_removed   = '~_'
 <
 You can use unicode characters but not images.  Signs must not take up more than

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -62,7 +62,7 @@ else
   call s:set('g:gitgutter_sign_removed_first_line', '_^')
 endif
 
-call s:set('g:gitgutter_sign_removed_above_and_below', '_‾')
+call s:set('g:gitgutter_sign_removed_above_and_below', '_¯')
 call s:set('g:gitgutter_sign_modified_removed',       '~_')
 call s:set('g:gitgutter_git_args',                      '')
 call s:set('g:gitgutter_diff_relative_to',         'index')


### PR DESCRIPTION
# problem
Currently, in my vim environment, the following error occurs at startup. (encoding=utf-8)
```
my-terminal $ vim
Error detected while processing function gitgutter#highlight#define_signs[8]..<SNR>31_define_sign_text:
line    5:
E239: Invalid sign text: _‾
```

According to vim doc, text option of sign must fit within two display cells. It is considered that the above error is due to the fact that this constraint is not satisfied when `_` and the character string(`‾`) are combined, because `‾` is a full-width character.
```
	text={text}						*E239*
		Define the text that is displayed when there is no icon or the
		GUI is not being used.  Only printable characters are allowed
		and they must occupy one or two display cells.
```

# solution
Use half-width strings instead of full-width strings.
`‾`(Unicode: FFE3) → `¯`(Unicode: 00AF)

