### PR TITLE
Set GitGutter colors, but respect defaults if they exist

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -320,18 +320,6 @@ If you or your colourscheme has defined `GitGutter*` highlight groups, the plugi
 
 If you want the background colours to match the sign column, but don't want to update the `GitGutter*` groups yourself, you can get the plugin to do it:
 
-```viml
-let g:gitgutter_set_sign_backgrounds = 1
-```
-
-If no `GitGutter*` highlight groups exist, the plugin will check the `Diff*` highlight groups.  If their foreground colours differ the plugin will use them; if not, these colours will be used:
-
-```viml
-highlight GitGutterAdd    guifg=#009900 ctermfg=2
-highlight GitGutterChange guifg=#bbbb00 ctermfg=3
-highlight GitGutterDelete guifg=#ff2222 ctermfg=1
-```
-
 To customise the symbols, add the following to your `~/.vimrc`:
 
 ```viml

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -70,29 +70,21 @@ function! gitgutter#highlight#define_highlights() abort
   " Highlights used by the signs.
 
   " When they are invisible.
-  execute "highlight GitGutterAddInvisible    guifg=bg guibg=" . guibg . " ctermfg=" . ctermbg . " ctermbg=" . ctermbg
-  execute "highlight GitGutterChangeInvisible guifg=bg guibg=" . guibg . " ctermfg=" . ctermbg . " ctermbg=" . ctermbg
-  execute "highlight GitGutterDeleteInvisible guifg=bg guibg=" . guibg . " ctermfg=" . ctermbg . " ctermbg=" . ctermbg
+  execute "highlight def GitGutterAddInvisible    guifg=bg guibg=" . guibg . " ctermfg=" . ctermbg . " ctermbg=" . ctermbg
+  execute "highlight def GitGutterChangeInvisible guifg=bg guibg=" . guibg . " ctermfg=" . ctermbg . " ctermbg=" . ctermbg
+  execute "highlight def GitGutterDeleteInvisible guifg=bg guibg=" . guibg . " ctermfg=" . ctermbg . " ctermbg=" . ctermbg
   highlight default link GitGutterChangeDeleteInvisible GitGutterChangeInvisible
 
   " When they are visible.
   for type in ["Add", "Change", "Delete"]
-    if hlexists("GitGutter".type)
-      if g:gitgutter_set_sign_backgrounds
-        execute "highlight GitGutter".type." guibg=".guibg." ctermbg=".ctermbg
-      endif
-      continue
-    elseif s:useful_diff_colours()
+    if s:useful_diff_colours()
       let [guifg, ctermfg] = s:get_foreground_colors('Diff'.type)
     else
       let [guifg, ctermfg] = s:get_foreground_fallback_colors(type)
     endif
-    execute "highlight GitGutter".type." guifg=".guifg." guibg=".guibg." ctermfg=".ctermfg." ctermbg=".ctermbg
-  endfor
 
-  if hlexists("GitGutterChangeDelete") && g:gitgutter_set_sign_backgrounds
-    execute "highlight GitGutterChangeDelete guibg=".guibg." ctermbg=".ctermbg
-  endif
+    execute "highlight def GitGutter".type." guifg=".guifg." guibg=".guibg." ctermfg=".ctermfg." ctermbg=".ctermbg
+  endfor
 
   highlight default link GitGutterChangeDelete GitGutterChange
 

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -306,7 +306,6 @@ Signs:~
     |g:gitgutter_sign_removed|
     |g:gitgutter_sign_removed_first_line|
     |g:gitgutter_sign_modified_removed|
-    |g:gitgutter_set_sign_backgrounds|
 
 Hunk previews:~
 
@@ -452,15 +451,6 @@ Defaults:
 You can use unicode characters but not images.  Signs must not take up more than
 2 columns.
 
-                                              *g:gitgutter_set_sign_backgrounds*
-Default: 0
-
-Only applies to existing GitGutter* highlight groups.  See
-|gitgutter-highlights|.
-
-Controls whether to override the signs' background colours to match the
-|hl-SignColumn|.
-
                                              *g:gitgutter_preview_win_floating*
 Default: 0 (Vim)
          0 (NeoVim which does not support floating windows)
@@ -535,10 +525,6 @@ To change the signs' colours, specify these highlight groups in your |vimrc|:
 <
 
 See |highlight-guifg| and |highlight-ctermfg| for the values you can use.
-
-If you do not like the signs' background colours and you do not want to update
-the GitGutter* highlight groups yourself, you can get the plugin to do it
-|g:gitgutter_set_sign_backgrounds|.
 
 To change the line highlights, set up the following highlight groups in your
 colorscheme or |vimrc|:

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -51,7 +51,6 @@ if (has('nvim-0.4.0') || exists('*sign_place')) && !exists('g:gitgutter_sign_all
   let g:gitgutter_sign_allow_clobber = 1
 endif
 call s:set('g:gitgutter_sign_allow_clobber',          0)
-call s:set('g:gitgutter_set_sign_backgrounds',           0)
 call s:set('g:gitgutter_sign_added',                   '+')
 call s:set('g:gitgutter_sign_modified',                '~')
 call s:set('g:gitgutter_sign_removed',                 '_')


### PR DESCRIPTION
Set GitGutter colors, but respect defaults if they exist. No need for `set_sign_backgrounds` (which didn't work anyway).

This plugin was checking for whether certain highlights already existed, and then tried to avoid setting them if they did. The `:h :highlight-default` option does this for you; by saying `highlight def GitGutterAdd` instead of just `highlight GitGutterAdd`, GitGutter will leave any user-defined highlighting alone. This way GitGutter provides "sane defaults" (using the values for DiffAdd and DiffDelete etc.), but won't override a user's colors.

This PR will allow you to change colorschemes while GitGutter is loaded without GitGutter "going blank" on its colors.

