### PR TITLE
Revise highlight logic to be simpler and obey user settings

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -318,10 +318,11 @@ let g:gitgutter_sign_allow_clobber = 1
 
 If you or your colourscheme has defined `GitGutter*` highlight groups, the plugin will use them for the signs' colours.
 
-If you want the background colours to match the sign column, but don't want to update the `GitGutter*` groups yourself, you can get the plugin to do it:
+If you do not want the plugin to automatically match the sign background
+colours, you can prevent it from doing so:
 
 ```viml
-let g:gitgutter_set_sign_backgrounds = 1
+let g:gitgutter_set_sign_backgrounds = 0
 ```
 
 If no `GitGutter*` highlight groups exist, the plugin will check the `Diff*` highlight groups.  If their foreground colours differ the plugin will use them; if not, these colours will be used:

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -77,17 +77,20 @@ function! gitgutter#highlight#define_highlights() abort
 
   " When they are visible.
   for type in ["Add", "Change", "Delete"]
-    if hlexists("GitGutter".type) && s:get_foreground_colors("GitGutter".type) != ['NONE', 'NONE']
-      if g:gitgutter_set_sign_backgrounds
-        execute "highlight GitGutter".type." guibg=".guibg." ctermbg=".ctermbg
-      endif
-      continue
-    elseif s:useful_diff_colours()
-      let [guifg, ctermfg] = s:get_foreground_colors('Diff'.type)
-    else
-      let [guifg, ctermfg] = s:get_foreground_fallback_colors(type)
+    " If the user wants us to set the background highlight, do so
+    if g:gitgutter_set_sign_backgrounds
+      execute "highlight GitGutter".type." guibg=".guibg." ctermbg=".ctermbg
     endif
-    execute "highlight GitGutter".type." guifg=".guifg." guibg=".guibg." ctermfg=".ctermfg." ctermbg=".ctermbg
+
+    " If the user does not have meaningful foreground highlights, set them for them
+    if !hlexists("GitGutter".type) || s:get_foreground_colors("GitGutter".type) == ['NONE', 'NONE']
+      if s:useful_diff_colours()
+        let [guifg, ctermfg] = s:get_foreground_colors('Diff'.type)
+      else
+        let [guifg, ctermfg] = s:get_foreground_fallback_colors(type)
+      endif
+      execute "highlight GitGutter".type." guifg=".guifg." ctermfg=".ctermfg
+    endif
   endfor
 
   if hlexists("GitGutterChangeDelete") && g:gitgutter_set_sign_backgrounds

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -77,27 +77,22 @@ function! gitgutter#highlight#define_highlights() abort
 
   " When they are visible.
   for type in ["Add", "Change", "Delete"]
+    if s:useful_diff_colours()
+      let [guifg, ctermfg] = s:get_foreground_colors('Diff'.type)
+    else
+      let [guifg, ctermfg] = s:get_foreground_fallback_colors(type)
+    endif
+    execute "highlight default GitGutter".type." guifg=".guifg." ctermfg=".ctermfg
+
     " If the user wants us to set the background highlight, do so
     if g:gitgutter_set_sign_backgrounds
       execute "highlight GitGutter".type." guibg=".guibg." ctermbg=".ctermbg
     endif
-
-    " If the user does not have meaningful foreground highlights, set them for them
-    if !hlexists("GitGutter".type) || s:get_foreground_colors("GitGutter".type) == ['NONE', 'NONE']
-      if s:useful_diff_colours()
-        let [guifg, ctermfg] = s:get_foreground_colors('Diff'.type)
-      else
-        let [guifg, ctermfg] = s:get_foreground_fallback_colors(type)
-      endif
-      execute "highlight GitGutter".type." guifg=".guifg." ctermfg=".ctermfg
-    endif
   endfor
 
-  if hlexists("GitGutterChangeDelete") && g:gitgutter_set_sign_backgrounds
-    execute "highlight GitGutterChangeDelete guibg=".guibg." ctermbg=".ctermbg
+  if !hlexists("GitGutterChangeDelete")
+    highlight default link GitGutterChangeDelete GitGutterChange
   endif
-
-  highlight default link GitGutterChangeDelete GitGutterChange
 
   " Highlights used for the whole line.
 

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -82,17 +82,10 @@ function! gitgutter#highlight#define_highlights() abort
     else
       let [guifg, ctermfg] = s:get_foreground_fallback_colors(type)
     endif
-    execute "highlight default GitGutter".type." guifg=".guifg." ctermfg=".ctermfg
-
-    " If the user wants us to set the background highlight, do so
-    if g:gitgutter_set_sign_backgrounds
-      execute "highlight GitGutter".type." guibg=".guibg." ctermbg=".ctermbg
-    endif
+    execute "highlight default GitGutter".type." guifg=".guifg." ctermfg=".ctermfg." guibg=".guibg." ctermbg=".ctermbg
   endfor
 
-  if !hlexists("GitGutterChangeDelete")
-    highlight default link GitGutterChangeDelete GitGutterChange
-  endif
+  highlight default link GitGutterChangeDelete GitGutterChange
 
   " Highlights used for the whole line.
 

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -453,7 +453,7 @@ You can use unicode characters but not images.  Signs must not take up more than
 2 columns.
 
                                               *g:gitgutter_set_sign_backgrounds*
-Default: 0
+Default: 1
 
 Only applies to existing GitGutter* highlight groups.  See
 |gitgutter-highlights|.

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -51,7 +51,7 @@ if (has('nvim-0.4.0') || exists('*sign_place')) && !exists('g:gitgutter_sign_all
   let g:gitgutter_sign_allow_clobber = 1
 endif
 call s:set('g:gitgutter_sign_allow_clobber',          0)
-call s:set('g:gitgutter_set_sign_backgrounds',           0)
+call s:set('g:gitgutter_set_sign_backgrounds',           1)
 call s:set('g:gitgutter_sign_added',                   '+')
 call s:set('g:gitgutter_sign_modified',                '~')
 call s:set('g:gitgutter_sign_removed',                 '_')


### PR DESCRIPTION
I still think there's some inconsistency in this highlight logic that needs to be resolved. Here's a matrix of behaviors when different settings are set by the user:

### master

|                    | set_sign_bg 0    | set_sign_bg 1    |
|--------------------|------------------|------------------|
| fg unset, bg unset | sets fg, sets bg | sets fg, sets bg |
| fg set, bg unset   | does nothing     | sets bg          |
| fg set, bg set     | does nothing     | sets bg          |
| fg unset, bg set   | sets bg          | sets bg          |

### pr 729

|                    | set_sign_bg 0 | set_sign_bg 1    |
|--------------------|---------------|------------------|
| fg unset, bg unset | sets fg       | sets fg, sets bg |
| fg set, bg unset   | does nothing  | sets bg          |
| fg set, bg set     | does nothing  | sets bg          |
| fg unset, bg set   | does nothing  | sets bg          |

In `master`, there are two scenarios where `set_sign_bg` is `0` and the background still gets set by the plugin.

Is this plugin trying to do too much for the user? Should it maybe just do:

```vim
execute "highlight default GitGutter".type." guifg=".guifg." ctermfg=".ctermfg." guibg=".guibg." ctermbg=".ctermbg
```

and if the user is setting colors themselves, then they can just take care of it on their own? Otherwise, I feel like this is the behavior we should maybe be seeing:

|          | fg unset         | fg set       |
|----------|------------------|--------------|
| bg unset | sets fg, sets bg | sets bg      |
| bg set   | sets fg          | does nothing |


