### PR TITLE
[doc] metion the plugin vim-tmux-focus-events

### DIFF
--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -491,6 +491,8 @@ If you use tmux, try this in your tmux.conf:
 >
     set -g focus-events on
 <
+If it still doesn't work try using the following plugin:
+https://github.com/tmux-plugins/vim-tmux-focus-events
 
 When this option is 0, the plugin force-updates the buffer on |BufEnter|
 (instead of only updating if the buffer's contents has changed since the last


### PR DESCRIPTION
By default tmux doesn't send focus-events. The result is that the
autocmd `FocusGained` isn't triggered. The docs already mention to set
`set -g focus-events on` in the tmux.conf. However, gitgutter still
wouldn't update the signs when I committed the changes outside of vim.
To get it working I had to install the following plugin: [vim-tmux-focus-events](https://github.com/tmux-plugins/vim-tmux-focus-events)
I think it would be great to mention this plugin in the docs so other
tmux-users are able to fix this issue quickly.