### PR TITLE
New GitGutterSignsColumnToggle Feature!

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -317,6 +317,12 @@ By default the sign column will appear when there are signs to show and disappea
 set signcolumn=yes
 ```
 
+Or to toggle it, simply map the following command to any key in your vimrc:
+
+```
+:GitGutterSignsColumnToggle
+```
+
 GitGutter can preserve or ignore non-gitgutter signs.  For Vim v8.1.0614 and later you can set gitgutter's signs' priorities with `g:gitgutter_sign_priority`, so gitgutter defaults to clobbering other signs.  For Neovim v0.4.0 and later you can set an expanding sign column so gitgutter again defaults to clobbering other signs.  Otherwise, gitgutter defaults to preserving other signs.  You can configure this with:
 
 ```viml

--- a/README.mkd
+++ b/README.mkd
@@ -319,7 +319,8 @@ set signcolumn=yes
 
 Or to toggle it, simply map the following command to any key in your vimrc:
 
-```
+```viml
+" Toggle signs column
 :GitGutterSignsColumnToggle
 ```
 

--- a/autoload/gitgutter/sign.vim
+++ b/autoload/gitgutter/sign.vim
@@ -247,16 +247,4 @@ function! s:highlight_name_for_change(text) abort
   endif
 endfunction
 
-" Sign column feature disabled by default.
-let g:gitgutter_signs_column_toggle = 0
-if g:gitgutter_signs_column_toggle == 1
-    function! GitGutterSignsColumnToggle()
-        if &signcolumn == "yes"
-            set signcolumn=no
-        else
-            set signcolumn=yes
-        endif
-    endfunction
-    " Command to toggle
-    command! GitGutterSignsColumnToggle execute "call GitGutterSignsColumnToggle()"
-endif
+

--- a/autoload/gitgutter/sign.vim
+++ b/autoload/gitgutter/sign.vim
@@ -247,4 +247,16 @@ function! s:highlight_name_for_change(text) abort
   endif
 endfunction
 
-
+" Sign column feature disabled by default.
+let g:gitgutter_signs_column_toggle = 0
+if g:gitgutter_signs_column_toggle == 1
+    function! GitGutterSignsColumnToggle()
+        if &signcolumn == "yes"
+            set signcolumn=no
+        else
+            set signcolumn=yes
+        endif
+    endfunction
+    " Command to toggle
+    command! GitGutterSignsColumnToggle execute "call GitGutterSignsColumnToggle()"
+endif

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -301,3 +301,17 @@ augroup END
 " }}}
 
 " vim:set et sw=2 fdm=marker:
+
+" Signs column toggle feature
+let g:gitgutter_signs_column_toggle = 1
+if g:gitgutter_signs_column_toggle == 1
+    function! GitGutterSignsColumnToggle()
+        if &signcolumn == "yes"
+            set signcolumn=no
+        else
+            set signcolumn=yes
+        endif
+    endfunction
+    " Command to toggle
+    command! GitGutterSignsColumnToggle execute "call GitGutterSignsColumnToggle()"
+endif


### PR DESCRIPTION
I have added a new feature that enables you to toggle the signs column on/off. It made it annoying to have to copy text from vim and have the empty column also get copied. Hope you guys accept to merge the feature.. And if maybe its not in the correct format, I'd appreciate it if you'd accept and move it where ever its supposed to go. I honestly didn't know where these types of features could be placed in. Best of luck to you guys 👍 