### PR TITLE
Fix when pwsh or powershell is used as shell with a parameter.

### DIFF
--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -180,7 +180,7 @@ function! s:use_known_shell() abort
     let &shell = 'sh'
     set shellcmdflag=-c shellredir=>%s\ 2>&1
   endif
-  if has('win32') && (&shell ==# 'pwsh' || &shell ==# 'powershell')
+  if has('win32') && (&shell =~# 'pwsh' || &shell =~# 'powershell')
     let [s:shell, s:shellcmdflag, s:shellredir, s:shellpipe, s:shellquote, s:shellxquote] = [&shell, &shellcmdflag, &shellredir, &shellpipe, &shellquote, &shellxquote]
     let &shell = 'cmd.exe'
     set shellcmdflag=/s\ /c shellredir=>%s\ 2>&1 shellpipe=>%s\ 2>&1 shellquote= shellxquote="


### PR DESCRIPTION
Like `set shell=pwsh\ -NoLogo`.

Actually, only `pwsh` or `powershell` are tested so use them with a parameter crash. See https://github.com/airblade/vim-gitgutter/issues/751.