### PR TITLE
Clean up warning messages

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -260,7 +260,7 @@ function! s:hunk_op(op, ...)
     call gitgutter#diff#process_hunks(bufnr, gitgutter#hunk#hunks(bufnr))  " so the hunk summary is updated
 
     if empty(s:current_hunk())
-      call gitgutter#utility#warn('cursor is not in a hunk')
+      call gitgutter#utility#warn('Cursor is not in a hunk')
     elseif s:cursor_in_two_hunks()
       let choice = input('Choose hunk: upper or lower (u/l)? ')
       " Clear input
@@ -270,7 +270,7 @@ function! s:hunk_op(op, ...)
       elseif choice =~ 'l'
         call a:op(gitgutter#diff#hunk_diff(bufnr, diff, 1))
       else
-        call gitgutter#utility#warn('did not recognise your choice')
+        call gitgutter#utility#warn('Did not recognise your choice')
       endif
     else
       let hunk_diff = gitgutter#diff#hunk_diff(bufnr, diff)
@@ -294,7 +294,7 @@ function! s:stage(hunk_diff)
         \ gitgutter#utility#cd_cmd(bufnr, g:gitgutter_git_executable.' '.g:gitgutter_git_args.' apply --cached --unidiff-zero - '),
         \ diff)
   if v:shell_error
-    call gitgutter#utility#warn('patch does not apply')
+    call gitgutter#utility#warn('Patch does not apply')
   else
     if exists('#User#GitGutterStage')
       execute 'doautocmd' s:nomodeline 'User GitGutterStage'

--- a/autoload/gitgutter/utility.vim
+++ b/autoload/gitgutter/utility.vim
@@ -30,7 +30,7 @@ endfunction
 
 function! gitgutter#utility#warn(message) abort
   echohl WarningMsg
-  echo 'vim-gitgutter: ' . a:message
+  echo a:message
   echohl None
   let v:warningmsg = a:message
 endfunction
@@ -39,7 +39,7 @@ function! gitgutter#utility#warn_once(bufnr, message, key) abort
   if empty(gitgutter#utility#getbufvar(a:bufnr, a:key))
     call gitgutter#utility#setbufvar(a:bufnr, a:key, '1')
     echohl WarningMsg
-    redraw | echom 'vim-gitgutter: ' . a:message
+    redraw | echom a:message
     echohl None
     let v:warningmsg = a:message
   endif

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -8,7 +8,7 @@ let g:loaded_gitgutter = 1
 " Initialisation {{{
 
 if v:version < 703 || (v:version == 703 && !has("patch105"))
-  call gitgutter#utility#warn('requires Vim 7.3.105')
+  call gitgutter#utility#warn('Requires Vim 7.3.105')
   finish
 endif
 
@@ -72,7 +72,7 @@ let g:gitgutter_show_msg_on_hunk_jumping     = get(g:, 'gitgutter_show_msg_on_hu
 let g:gitgutter_git_executable = get(g:, 'gitgutter_git_executable', 'git')
 if !executable(g:gitgutter_git_executable)
   if g:gitgutter_enabled
-    call gitgutter#utility#warn('cannot find git. Please set g:gitgutter_git_executable.')
+    call gitgutter#utility#warn('Cannot find git. Please set g:gitgutter_git_executable.')
   endif
   finish
 endif
@@ -86,7 +86,7 @@ if !empty(g:gitgutter_grep)
     endif
   else
     if g:gitgutter_grep !=# default_grep
-      call gitgutter#utility#warn('cannot find '.g:gitgutter_grep.'. Please check g:gitgutter_grep.')
+      call gitgutter#utility#warn('Cannot find '.g:gitgutter_grep.'. Please check g:gitgutter_grep.')
     endif
     let g:gitgutter_grep = ''
   endif
@@ -202,18 +202,18 @@ command! -bar GitGutterDebug call gitgutter#debug#debug()
 " Maps {{{
 
 nnoremap <silent> <expr> <Plug>(GitGutterNextHunk) &diff ? ']c' : ":\<C-U>execute v:count1 . 'GitGutterNextHunk'\<CR>"
-nnoremap <silent> <expr> <Plug>GitGutterNextHunk   &diff ? ']c' : ":\<C-U>call gitgutter#utility#warn('please change your map \<lt>Plug>GitGutterNextHunk to \<lt>Plug>(GitGutterNextHunk)')\<CR>"
+nnoremap <silent> <expr> <Plug>GitGutterNextHunk   &diff ? ']c' : ":\<C-U>call gitgutter#utility#warn('Please change your map \<lt>Plug>GitGutterNextHunk to \<lt>Plug>(GitGutterNextHunk)')\<CR>"
 nnoremap <silent> <expr> <Plug>(GitGutterPrevHunk) &diff ? '[c' : ":\<C-U>execute v:count1 . 'GitGutterPrevHunk'\<CR>"
-nnoremap <silent> <expr> <Plug>GitGutterPrevHunk   &diff ? '[c' : ":\<C-U>call gitgutter#utility#warn('please change your map \<lt>Plug>GitGutterPrevHunk to \<lt>Plug>(GitGutterPrevHunk)')\<CR>"
+nnoremap <silent> <expr> <Plug>GitGutterPrevHunk   &diff ? '[c' : ":\<C-U>call gitgutter#utility#warn('Please change your map \<lt>Plug>GitGutterPrevHunk to \<lt>Plug>(GitGutterPrevHunk)')\<CR>"
 
 xnoremap <silent> <Plug>(GitGutterStageHunk)   :GitGutterStageHunk<CR>
-xnoremap <silent> <Plug>GitGutterStageHunk     :call gitgutter#utility#warn('please change your map <lt>Plug>GitGutterStageHunk to <lt>Plug>(GitGutterStageHunk)')<CR>
+xnoremap <silent> <Plug>GitGutterStageHunk     :call gitgutter#utility#warn('Please change your map <lt>Plug>GitGutterStageHunk to <lt>Plug>(GitGutterStageHunk)')<CR>
 nnoremap <silent> <Plug>(GitGutterStageHunk)   :GitGutterStageHunk<CR>
-nnoremap <silent> <Plug>GitGutterStageHunk     :call gitgutter#utility#warn('please change your map <lt>Plug>GitGutterStageHunk to <lt>Plug>(GitGutterStageHunk)')<CR>
+nnoremap <silent> <Plug>GitGutterStageHunk     :call gitgutter#utility#warn('Please change your map <lt>Plug>GitGutterStageHunk to <lt>Plug>(GitGutterStageHunk)')<CR>
 nnoremap <silent> <Plug>(GitGutterUndoHunk)    :GitGutterUndoHunk<CR>
-nnoremap <silent> <Plug>GitGutterUndoHunk      :call gitgutter#utility#warn('please change your map <lt>Plug>GitGutterUndoHunk to <lt>Plug>(GitGutterUndoHunk)')<CR>
+nnoremap <silent> <Plug>GitGutterUndoHunk      :call gitgutter#utility#warn('Please change your map <lt>Plug>GitGutterUndoHunk to <lt>Plug>(GitGutterUndoHunk)')<CR>
 nnoremap <silent> <Plug>(GitGutterPreviewHunk) :GitGutterPreviewHunk<CR>
-nnoremap <silent> <Plug>GitGutterPreviewHunk   :call gitgutter#utility#warn('please change your map <lt>Plug>GitGutterPreviewHunk to <lt>Plug>(GitGutterPreviewHunk)')<CR>
+nnoremap <silent> <Plug>GitGutterPreviewHunk   :call gitgutter#utility#warn('Please change your map <lt>Plug>GitGutterPreviewHunk to <lt>Plug>(GitGutterPreviewHunk)')<CR>
 
 " }}}
 


### PR DESCRIPTION
IMO warning messages are cleaner without the plugin name in. What do you think ?

![Screenshot 2021-04-22 at 11 40 31](https://user-images.githubusercontent.com/7091110/115693098-e4285080-a35f-11eb-9bf2-2b9df2e8713a.png)

vs

![Screenshot 2021-04-22 at 11 39 50](https://user-images.githubusercontent.com/7091110/115693115-e8546e00-a35f-11eb-95dc-f79ad4da28b9.png)
