### PR TITLE
GitGutterQuickFix for current file.

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -179,7 +179,7 @@ endfunction
 " - this runs synchronously
 " - it ignores unsaved changes in buffers
 " - it does not change to the repo root
-function! gitgutter#quickfix()
+function! gitgutter#quickfix(current_file)
   let cmd = g:gitgutter_git_executable.' '.g:gitgutter_git_args.' rev-parse --show-cdup'
   let path_to_repo = get(systemlist(cmd), 0, '')
   if !empty(path_to_repo) && path_to_repo[-1:] != '/'
@@ -191,6 +191,9 @@ function! gitgutter#quickfix()
         \ ' diff --no-ext-diff --no-color -U0'.
         \ ' --src-prefix=a/'.path_to_repo.' --dst-prefix=b/'.path_to_repo.' '.
         \ g:gitgutter_diff_args. ' '. g:gitgutter_diff_base
+  if a:current_file
+    let cmd = cmd.' -- '.expand('%:p')
+  endif
   let diff = systemlist(cmd)
   let lnum = 0
   for line in diff

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -158,6 +158,11 @@ Commands for jumping between hunks:~
 >
                           command! Gqf GitGutterQuickFix | copen
 <
+                                                 *gitgutter-:GitGutterQuickFixCurrentFile*
+:GitGutterQuickFixCurrentFile     Same as :GitGutterQuickFix, but only load hunks for
+                                  the file in the focused buffer. This has the same
+                                  functionality as :GitGutterQuickFix when the focused
+                                  buffer is empty.
 
 
 Commands for operating on a hunk:~

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -118,7 +118,8 @@ command! -bar GitGutterBufferDisable call gitgutter#buffer_disable()
 command! -bar GitGutterBufferEnable  call gitgutter#buffer_enable()
 command! -bar GitGutterBufferToggle  call gitgutter#buffer_toggle()
 
-command! -bar GitGutterQuickFix call gitgutter#quickfix()
+command! -bar GitGutterQuickFix call gitgutter#quickfix(v:false)
+command! -bar GitGutterQuickFixCurrentFile call gitgutter#quickfix(v:true)
 
 " }}}
 

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -118,8 +118,8 @@ command! -bar GitGutterBufferDisable call gitgutter#buffer_disable()
 command! -bar GitGutterBufferEnable  call gitgutter#buffer_enable()
 command! -bar GitGutterBufferToggle  call gitgutter#buffer_toggle()
 
-command! -bar GitGutterQuickFix call gitgutter#quickfix(v:false)
-command! -bar GitGutterQuickFixCurrentFile call gitgutter#quickfix(v:true)
+command! -bar GitGutterQuickFix call gitgutter#quickfix(0)
+command! -bar GitGutterQuickFixCurrentFile call gitgutter#quickfix(1)
 
 " }}}
 


### PR DESCRIPTION
Appends the path to the current file to the `git diff` command when `g:gitgutter_use_location_list = 1`.

New behavior:
* loclist only contains hunks of current file
* if current file is not within the repo, the loclist is empty
* if current buffer does not have a file loaded, the loclist is empty

I personally think this change is sensible when using the loclist. My personal config is (its neovim lua, but should make sense)
```
util.set_normal_keymap('<leader>ghq', util.cmd('GitGutterQuickFix') .. util.cmd('copen'))
util.set_normal_keymap('<leader>ghl', util.lua_cmd('vim.g.gitgutter_use_location_list=1') ..
    util.cmd('GitGutterQuickFix') .. util.lua_cmd('vim.g.gitgutter_use_location_list=0') .. util.cmd('lopen'))
```
I have keymaps to view hunks for the entire project, or just the current file. I can use the loclist by setting `g:gitgutter_use_location_list=1`, and then resetting it back to 0 afterwards.