### PR TITLE
Make intra-highlights customizable

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -283,6 +283,9 @@ You can customise:
 * How to handle non-gitgutter signs
 * The signs' colours and symbols
 * Line highlights
+* Line number highlights (only in Neovim 0.3.2 or higher)
+* The diff syntax colours used in the preview window
+* The intra-line diff highlights used in the preview window
 * Whether the diff is relative to the index (default) or working tree.
 * The base of the diff
 * Extra arguments for `git` when running `git diff`
@@ -392,6 +395,35 @@ Maybe you think `CursorLineNr` is a bit annoying.  For example, you could use `U
 
 ```viml
 highlight link GitGutterChangeLineNr Underlined
+```
+
+
+#### The diff syntax colours used in the preview window
+
+To change the diff syntax colours used in the preview window, set up the `diff*` highlight groups in your colorscheme or `~/.vimrc`:
+
+```viml
+diffAdded   " if not set: use GitGutterAdd's foreground colour
+diffChanged " if not set: use GitGutterChange's foreground colour
+diffRemoved " if not set: use GitGutterDelete's foreground colour
+```
+
+Note the `diff*` highlight groups are used in any buffer whose `'syntax'` is `diff`.
+
+
+#### The intra-line diff highlights used in the preview window
+
+To change the intra-line diff highlights used in the preview window, set up the following highlight groups in your colorscheme or `~/.vimrc`:
+
+```viml
+GitGutterAddIntraLine    " default: gui=reverse cterm=reverse
+GitGutterDeleteIntraLine " default: gui=reverse cterm=reverse
+```
+
+For example, to use `DiffAdd` for intra-line added regions:
+
+```viml
+highlight link GitGutterAddIntraLine DiffAdd
 ```
 
 

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -109,8 +109,8 @@ function! gitgutter#highlight#define_highlights() abort
   highlight default link GitGutterChangeDeleteLineNr CursorLineNr
 
   " Highlights used intra line.
-  highlight GitGutterAddIntraLine    gui=reverse cterm=reverse
-  highlight GitGutterDeleteIntraLine gui=reverse cterm=reverse
+  highlight default GitGutterAddIntraLine    gui=reverse cterm=reverse
+  highlight default GitGutterDeleteIntraLine gui=reverse cterm=reverse
   " Set diff syntax colours (used in the preview window) - diffAdded,diffChanged,diffRemoved -
   " to match the signs, if not set aleady.
   for [dtype,type] in [['Added','Add'], ['Changed','Change'], ['Removed','Delete']]

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -608,6 +608,26 @@ For example, to use |hl-Underlined| instead of |hl-CursorLineNr|:
 >
     highlight link GitGutterChangeLineNr Underlined
 <
+To change the diff syntax colours used in the preview window, set up the diff*
+highlight groups in your colorscheme or |vimrc|:
+>
+    diffAdded   " if not set: use GitGutterAdd's foreground colour
+    diffChanged " if not set: use GitGutterChange's foreground colour
+    diffRemoved " if not set: use GitGutterDelete's foreground colour
+<
+Note the diff* highlight groups are used in any buffer whose 'syntax' is
+"diff".
+
+To change the intra-line diff highlights used in the preview window, set up
+the following highlight groups in your colorscheme or |vimrc|:
+>
+    GitGutterAddIntraLine    " default: gui=reverse cterm=reverse
+    GitGutterDeleteIntraLine " default: gui=reverse cterm=reverse
+<
+For example, to use |hl-DiffAdd| for intra-line added regions:
+>
+    highlight link GitGutterAddIntraLine DiffAdd
+<
 
 
 ===============================================================================


### PR DESCRIPTION
Hi @airblade.

Currently, the user cannot customize the color of the intra-highlights, "GitGutterAddIntraLine" and "GitGutterDeleteIntraLine", because we call the ":highlight" commands without "default" argument (:help :highlight-default). So I suggest adding it. What do you think?

Thank you.