### PR TITLE
fix quickfix for combined diffs

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -205,6 +205,10 @@ function! gitgutter#quickfix(current_file)
     elseif line =~ '^diff --git "'
       let [_, fnamel, _, fnamer] = split(line, '"')
       let fname = fnamel ==# fnamer ? fnamel : fnamel[2:]
+    elseif line =~ '^diff --cc [^"]'
+      let fname = line[10:]
+    elseif line =~ '^diff --cc "'
+      let [_, fname] = split(line, '"')
     elseif line =~ '^@@'
       let lnum = matchlist(line, '+\(\d\+\)')[1]
     elseif lnum > 0


### PR DESCRIPTION
This is a fix for an error I was getting when using GitGutterQuickFix on diffs with conflicts:

![ksnip_20210830-130651](https://user-images.githubusercontent.com/79985369/131323509-da00b92f-53dc-4c91-8f19-a0385d7ef77f.png)

Apparently, these diffs take `--cc` to produce output in the "combined" format.
git-diff(1) mentions `-c` too, but I haven't seen it in the wild.

On another note, both the existing and my new `elseif` branches for double-quoted filenames seem to get the special chars wrong.
If the filename contains, say, a Tab, the status line in vim displays something like `asdf^Iasdf`, but GitGutterQuickFix will try to open `asdf\tasdf`, which doesn't exist.
I haven't fixed that.