### PR TITLE
work around for neovim if | foo | endif issue

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -154,7 +154,9 @@ function! gitgutter#setup_maps()
 endfunction
 
 function! s:setup_path(bufnr, continuation)
-  if gitgutter#utility#has_repo_path(a:bufnr) | return | endif
+  if gitgutter#utility#has_repo_path(a:bufnr)
+    return
+  endif
 
   return gitgutter#utility#set_repo_path(a:bufnr, a:continuation)
 endfunction


### PR DESCRIPTION
Hi,
ty for awesome gitgutter.

We seem to hit E171: Missing :endif
when at :s/ in neovim
see neovim/neovim#8796
I am not sure how to fix in neovim, so this is a simple work-around.

thx,
-m