### PR TITLE
Always pass some group name to sign arguments

### DIFF
--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -175,12 +175,12 @@ function! s:define_sign_line_highlights() abort
     sign define GitGutterLineRemovedAboveAndBelow  linehl=GitGutterDeleteLine
     sign define GitGutterLineModifiedRemoved       linehl=GitGutterChangeDeleteLine
   else
-    sign define GitGutterLineAdded                 linehl=
-    sign define GitGutterLineModified              linehl=
-    sign define GitGutterLineRemoved               linehl=
-    sign define GitGutterLineRemovedFirstLine      linehl=
-    sign define GitGutterLineRemovedAboveAndBelow  linehl=
-    sign define GitGutterLineModifiedRemoved       linehl=
+    sign define GitGutterLineAdded                 linehl=None
+    sign define GitGutterLineModified              linehl=None
+    sign define GitGutterLineRemoved               linehl=None
+    sign define GitGutterLineRemovedFirstLine      linehl=None
+    sign define GitGutterLineRemovedAboveAndBelow  linehl=None
+    sign define GitGutterLineModifiedRemoved       linehl=None
   endif
 endfunction
 
@@ -195,12 +195,12 @@ function! s:define_sign_linenr_highlights() abort
         sign define GitGutterLineRemovedAboveAndBelow  numhl=GitGutterDeleteLineNr
         sign define GitGutterLineModifiedRemoved       numhl=GitGutterChangeDeleteLineNr
       else
-        sign define GitGutterLineAdded                 numhl=
-        sign define GitGutterLineModified              numhl=
-        sign define GitGutterLineRemoved               numhl=
-        sign define GitGutterLineRemovedFirstLine      numhl=
-        sign define GitGutterLineRemovedAboveAndBelow  numhl=
-        sign define GitGutterLineModifiedRemoved       numhl=
+        sign define GitGutterLineAdded                 numhl=None
+        sign define GitGutterLineModified              numhl=None
+        sign define GitGutterLineRemoved               numhl=None
+        sign define GitGutterLineRemovedFirstLine      numhl=None
+        sign define GitGutterLineRemovedAboveAndBelow  numhl=None
+        sign define GitGutterLineModifiedRemoved       numhl=None
       endif
     catch /E475/
     endtry


### PR DESCRIPTION
E.g., passing an empty group name to the sign argument linehl (e.g.,
"linehl=") causes the following error:

```
Error detected while processing /usr/home/0mp/.vim/plugged/vim-gitgutter/plugin/gitgutter.vim[96]..function gitgutter#highlight#define_signs[10]..<SNR>56_define_sign_line_highlights:
line    9:
E1249: Group name missing for linehl
```

This patch makes the those errors go away by passing "None" when no
group name is needed.