### PR TITLE
Fix `gitgutter#async#available` to check patch version properly.

### DIFF
--- a/autoload/gitgutter/async.vim
+++ b/autoload/gitgutter/async.vim
@@ -1,8 +1,8 @@
 let s:available = has('nvim') || (
       \   has('job') && (
-      \     (has('patch-7-4-1826') && !has('gui_running')) ||
-      \     (has('patch-7-4-1850') &&  has('gui_running')) ||
-      \     (has('patch-7-4-1832') &&  has('gui_macvim'))
+      \     (has('patch-7.4.1826') && !has('gui_running')) ||
+      \     (has('patch-7.4.1850') &&  has('gui_running')) ||
+      \     (has('patch-7.4.1832') &&  has('gui_macvim'))
       \   )
       \ )
 


### PR DESCRIPTION
As per `help has-patch` the patch version check should use `.` instead of `-`.

```help
<							*has-patch*
3.  Beyond a certain version or at a certain version and including a specific
    patch.  The "patch-7.4.248" feature means that the Vim version is 7.5 or
    later, or it is version 7.4 and patch 248 was included.  Example: >
	:if has("patch-7.4.248")
```

Note it is used properly in places like:
https://github.com/airblade/vim-gitgutter/blob/f19b6203191d69de955d91467a5707959572119b/autoload/gitgutter.vim#L30

Fixes: #841