### PR TITLE
Link highlight of GitGutterChangeDeleteLineNr to GitGutterChangeLineNr

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -375,7 +375,7 @@ Similarly to the signs' colours, set up the following highlight groups in your c
 GitGutterAddLine          " default: links to DiffAdd
 GitGutterChangeLine       " default: links to DiffChange
 GitGutterDeleteLine       " default: links to DiffDelete
-GitGutterChangeDeleteLine " default: links to GitGutterChangeLineDefault, i.e. DiffChange
+GitGutterChangeDeleteLine " default: links to GitGutterChangeLine, i.e. DiffChange
 ```
 
 For example, in some colorschemes the `DiffText` highlight group is easier to read than `DiffChange`.  You could use it like this:
@@ -395,7 +395,7 @@ Similarly to the signs' colours, set up the following highlight groups in your c
 GitGutterAddLineNr          " default: links to CursorLineNr
 GitGutterChangeLineNr       " default: links to CursorLineNr
 GitGutterDeleteLineNr       " default: links to CursorLineNr
-GitGutterChangeDeleteLineNr " default: links to CursorLineNr
+GitGutterChangeDeleteLineNr " default: links to GitGutterChangeLineNr
 ```
 
 Maybe you think `CursorLineNr` is a bit annoying.  For example, you could use `Underlined` for this:

--- a/autoload/gitgutter/highlight.vim
+++ b/autoload/gitgutter/highlight.vim
@@ -106,7 +106,7 @@ function! gitgutter#highlight#define_highlights() abort
   highlight default link GitGutterAddLineNr          CursorLineNr
   highlight default link GitGutterChangeLineNr       CursorLineNr
   highlight default link GitGutterDeleteLineNr       CursorLineNr
-  highlight default link GitGutterChangeDeleteLineNr CursorLineNr
+  highlight default link GitGutterChangeDeleteLineNr GitGutterChangeLineNr
 
   " Highlights used intra line.
   highlight default GitGutterAddIntraLine    gui=reverse cterm=reverse

--- a/doc/gitgutter.txt
+++ b/doc/gitgutter.txt
@@ -635,7 +635,7 @@ colorscheme or |vimrc|:
     GitGutterAddLine          " default: links to DiffAdd
     GitGutterChangeLine       " default: links to DiffChange
     GitGutterDeleteLine       " default: links to DiffDelete
-    GitGutterChangeDeleteLine " default: links to GitGutterChangeLineDefault
+    GitGutterChangeDeleteLine " default: links to GitGutterChangeLine
 <
 
 For example, to use |hl-DiffText| instead of |hl-DiffChange|:
@@ -648,7 +648,7 @@ your colorscheme or |vimrc|:
     GitGutterAddLineNr          " default: links to CursorLineNr
     GitGutterChangeLineNr       " default: links to CursorLineNr
     GitGutterDeleteLineNr       " default: links to CursorLineNr
-    GitGutterChangeDeleteLineNr " default: links to CursorLineNr
+    GitGutterChangeDeleteLineNr " default: links to GitGutterChangeLineNr
 <
 For example, to use |hl-Underlined| instead of |hl-CursorLineNr|:
 >


### PR DESCRIPTION
This matches the behavior of `GitGutterChangeDeleteLine` and `GitGutterChangeDelete`, i.e., the "ChangeDelete" version always links to "Change".

The assumption is that most users don't need to distinguish the two. Making this change is useful so that these user don't have to do this link by themselves.