### PR TITLE
Added :GitGutterDiffOrigToggle and made :GitGutterDiffOrig would not …

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -237,7 +237,16 @@ function! gitgutter#quickfix(current_file)
 endfunction
 
 
+let s:difforigbuffers = {}
+
 function! gitgutter#difforig()
+  for [k, v] in items(s:difforigbuffers)
+    if bufnr('%') == k && buflisted(v) || bufnr('%') == v
+      " This either already has an open difforig buffer or is a difforig
+      " buffer. Do nothing and return.
+      return
+    endif
+  endfor
   let bufnr = bufnr('')
   let path = gitgutter#utility#repo_path(bufnr, 1)
   let filetype = &filetype
@@ -262,4 +271,22 @@ function! gitgutter#difforig()
   diffthis
   wincmd p
   diffthis
+  let s:difforigbuffers[bufnr('%')] = bufnr('$')
+endfunction
+
+
+function! gitgutter#difforig_toggle()
+  for [k, v] in items(s:difforigbuffers)
+    if bufnr('%') == k && buflisted(v) || bufnr('%') == v
+      " This either already has a difforig buffer, or this is a difforig
+      " buffer. Close this file's difforig buffer and wipe it from the buffer
+      " list.
+      execute 'bwipeout ' . v
+      let s:difforigbuffers[k] = ''
+      return
+    endif
+  endfor
+
+  " Open a new difforig for the current buffer.
+  call gitgutter#difforig()
 endfunction

--- a/plugin/gitgutter.vim
+++ b/plugin/gitgutter.vim
@@ -135,6 +135,7 @@ command! -bar GitGutterQuickFix call gitgutter#quickfix(0)
 command! -bar GitGutterQuickFixCurrentFile call gitgutter#quickfix(1)
 
 command! -bar GitGutterDiffOrig call gitgutter#difforig()
+command! -bar GitGutterDiffOrigToggle call gitgutter#difforig_toggle()
 
 " }}}
 


### PR DESCRIPTION
…open duplicate difforig buffers

One feature I felt was lacking in gitgutter is a way to quickly pull up :GitGutterDIffOrig and then dismiss it just as quickly.

### How this works:
There is now a dictionary named s:difforigbuffers keyed to the buffer number of the buffer the diff is for with the value set to the number of the buffer that gets created. Whenever :GitGutterDiffOrigToggle or `gitgutter#difforig_toggle()` gets called it first loops through the `s:difforigbuffers`dictionary and checks if the current buffer number already exists as a key or value in the dictionary. If it is a value or it is a key that currently has a value that is a listed buffer then it closes the buffer and returns. If it isn't a key or isn't a value or the difforig buffer isn't listed then it calls gitgutter#difforig()

I also modified gitgutter#difforig() to check the same dictionary to prevent duplicate buffers from being created.

Let me know if there is anything that needs to be changes or if there are any weird edge cases I am not accounting for. Also I didn't know where to put the dictionary so I just put it above gitgutter#difforig()