### PR TITLE
fix(diff): Wrong diff if dos format combines with noeol

### DIFF
--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -407,7 +407,13 @@ function! s:write_buffer(bufnr, file)
   endif
 
   if getbufvar(a:bufnr, '&fileformat') ==# 'dos'
-    call map(bufcontents, 'v:val."\r"')
+    if getbufvar(a:bufnr, '&endofline')
+      call map(bufcontents, 'v:val."\r"')
+    else
+      for i in range(len(bufcontents) - 1)
+        let bufcontents[i] = bufcontents[i] . "\r"
+      endfor
+    endif
   endif
 
   if getbufvar(a:bufnr, '&endofline')


### PR DESCRIPTION
If fileformat is dos and eol is not set, then a '\r' (but without '\n') will be written to the last line of temporary buffer file, which will confuse git and make git think all lines are modified. Fix it by adding 'r' to all lines except the last one if fileformat is dos and eol is not set.