### PR TITLE
Remove "file unknown in base" check

### DIFF
--- a/autoload/gitgutter.vim
+++ b/autoload/gitgutter.vim
@@ -46,8 +46,6 @@ function! gitgutter#process_buffer(bufnr, force) abort
         call gitgutter#debug#log('Not tracked: '.gitgutter#utility#file(a:bufnr))
       catch /gitgutter assume unchanged/
         call gitgutter#debug#log('Assume unchanged: '.gitgutter#utility#file(a:bufnr))
-      catch /gitgutter file unknown in base/
-        let diff = gitgutter#diff#hunk_header_showing_every_line_added(a:bufnr)
       catch /gitgutter diff failed/
         call gitgutter#debug#log('Diff failed: '.gitgutter#utility#file(a:bufnr))
         call gitgutter#hunk#reset(a:bufnr)

--- a/autoload/gitgutter/diff.vim
+++ b/autoload/gitgutter/diff.vim
@@ -81,20 +81,6 @@ function! gitgutter#diff#run_diff(bufnr, from, preserve_full_diff) abort
     throw 'gitgutter assume unchanged'
   endif
 
-  " If we are diffing against a specific branch/commit, handle the case
-  " where a file exists on the current branch but not in/at the diff base.
-  " We have to handle it here because the approach below (using git-show)
-  " doesn't work for this case.
-  if !empty(g:gitgutter_diff_base)
-    let index_name = gitgutter#utility#get_diff_base(a:bufnr).':'.gitgutter#utility#repo_path(a:bufnr, 1)
-    let cmd = gitgutter#git().' --no-pager show '.index_name
-    let cmd = gitgutter#utility#cd_cmd(a:bufnr, cmd)
-    let [_, error_code] = gitgutter#utility#system(cmd)
-    if error_code
-      throw 'gitgutter file unknown in base'
-    endif
-  endif
-
   " Wrap compound commands in parentheses to make Windows happy.
   " bash doesn't mind the parentheses.
   let cmd = '('
@@ -138,7 +124,7 @@ function! gitgutter#diff#run_diff(bufnr, from, preserve_full_diff) abort
 
     " Write file from index to temporary file.
     let index_name = gitgutter#utility#get_diff_base(a:bufnr).':'.gitgutter#utility#repo_path(a:bufnr, 1)
-    let cmd .= gitgutter#git().' --no-pager show --textconv '.index_name.' > '.from_file.' && '
+    let cmd .= gitgutter#git().' --no-pager show --textconv '.index_name.' > '.from_file.' || exit 0) && ('
 
   elseif a:from ==# 'working_tree'
     let from_file = gitgutter#utility#repo_path(a:bufnr, 1)
@@ -387,12 +373,6 @@ function! gitgutter#diff#hunk_diff(bufnr, full_diff, ...)
     endif
   endfor
   return join(modified_diff, "\n")."\n"
-endfunction
-
-
-function! gitgutter#diff#hunk_header_showing_every_line_added(bufnr)
-  let buf_line_count = getbufinfo(a:bufnr)[0].linecount
-  return '@@ -0,0 +1,'.buf_line_count.' @@'
 endfunction
 
 


### PR DESCRIPTION
Instead of checking whether this file exists in `diff_base` and returning early, we let `git show` fail, which still creates an empty `from_file` for the subsequent `git diff` to use.

This mostly reverts 2ee95686c5944f99b42dd04fec005b30497006de, but we keep the test case.

For posterity: this was originally meant to fix #869, but #870 accomplished that.