### PR TITLE
Respect &foldopen during next/prev hunk jumps

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -60,7 +60,8 @@ function! gitgutter#hunk#next_hunk(count) abort
     if hunk[2] > current_line
       let hunk_count += 1
       if hunk_count == a:count
-        execute 'normal!' hunk[2] . 'Gzv'
+        let keys = &foldopen =~# '\<block\>' ? 'zv' : ''
+        execute 'normal!' hunk[2] . 'G' . keys
         if g:gitgutter_show_msg_on_hunk_jumping
           redraw | echo printf('Hunk %d of %d', index(hunks, hunk) + 1, len(hunks))
         endif
@@ -90,8 +91,9 @@ function! gitgutter#hunk#prev_hunk(count) abort
     if hunk[2] < current_line
       let hunk_count += 1
       if hunk_count == a:count
+        let keys = &foldopen =~# '\<block\>' ? 'zv' : ''
         let target = hunk[2] == 0 ? 1 : hunk[2]
-        execute 'normal!' target . 'Gzv'
+        execute 'normal!' target . 'G' . keys
         if g:gitgutter_show_msg_on_hunk_jumping
           redraw | echo printf('Hunk %d of %d', index(hunks, hunk) + 1, len(hunks))
         endif


### PR DESCRIPTION
This makes the next/previous hunk block-style mappings respect the `&foldopen` setting by skipping `zv` if it does not contain the word `'block'`.

Think this would be more consistent with other vim behavior, and since `&foldopen` contains `'block'` by default it shouldn't affect the average user. However I can see the argument that this is a "breaking" change requiring an explicit setting like `g:gitgutter_respect_foldopen` (happy to update the PR if you feel this way).

Thanks for the awesome plugin!