### PR TITLE
Move to floating window upon retriggering preview

### DIFF
--- a/autoload/gitgutter/hunk.vim
+++ b/autoload/gitgutter/hunk.vim
@@ -359,6 +359,11 @@ endfunction
 
 
 function! s:preview(hunk_diff)
+  if g:gitgutter_preview_win_floating && exists('*nvim_set_current_win') && s:winid != 0
+    call nvim_set_current_win(s:winid)
+    return
+  endif
+
   let lines = split(a:hunk_diff, '\r\?\n')
   let header = lines[0:4]
   let body = lines[5:]


### PR DESCRIPTION
Moving to floating windows is sometimes quite frustrating, especially with multiple windows (the simplest case would be with a single split and attempting to navigate to the floating window via `<C-w>`. Some plugins have adopted a pattern to move to the floating window upon retriggering the command to open the float when the window is already open.